### PR TITLE
Refactor XcodeGen configs to use xcconfigs + remove hardcoded values from AuthenticationActor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ XCodeWrapper/Assets.xcassets/AppIcon.appiconset/*.png
 XCodeWrapper/WatchAssets.xcassets/AppIcon.appiconset/*.png
 XCodeWrapper/TVAssets.xcassets/**/*.png
 XCodeWrapper/Info-iOS.plist
+XCodeWrapper/Info-macOS.plist
+XCodeWrapper/Info-tvOS.plist
+XCodeWrapper/Info-watchOS.plist

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Packages/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 DerivedData/
 .netrc
+XCodeWrapper/Configs/Local.xcconfig
 .vscode/
 *.xcodeproj/
 .build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ In theory, `XCodeWrapper/` and `SilveranKit/` could be merged into one package f
 - Run `git submodule update --init` to checkout `extern/foliate-js`
 - Install `xcodegen` and `xcbeautify` from Homebrew.
 - Install Xcode CLI Tools and accept the Xcode license
+- Copy `XCodeWrapper/Configs/Local.example.xcconfig` to `XCodeWrapper/Configs/Local.xcconfig`.
+- Set `DEVELOPMENT_TEAM` in that file, and optionally override the bundle IDs and keychain settings for your local signing namespace.
 - Run `scripts/genxproj` before your initial build, or whenever `project.yml` changes. This script generates `Silveran.xcodeproj`.
 - Run `scripts/genicons` if you want the icon to have the correct icon. You will need `imagemagick` from Homebrew for this step.
 

--- a/SilveranKit/Sources/Common/Actors/AuthenticationActor.swift
+++ b/SilveranKit/Sources/Common/Actors/AuthenticationActor.swift
@@ -5,13 +5,18 @@ import Security
 public actor AuthenticationActor {
     public static let shared = AuthenticationActor()
 
-    private let service = "com.kyonifer.silveran.storyteller"
-    private let accessGroup = "9CJ7KG7UKQ.com.kyonifer.silveran.shared"
+    private let service: String
+    private let accessGroup: String
     private let serverURLKey = "serverURL"
     private let usernameKey = "username"
     private let passwordKey = "password"
+    private static let serviceInfoKey = "KEYCHAIN_SERVICE"
+    private static let accessGroupInfoKey = "KEYCHAIN_ACCESS_GROUP"
 
-    private init() {}
+    private init() {
+        service = Self.requiredInfoValue(for: Self.serviceInfoKey)
+        accessGroup = Self.requiredInfoValue(for: Self.accessGroupInfoKey)
+    }
 
     public func saveCredentials(url: String, username: String, password: String) async throws {
         try await deleteCredentials()
@@ -109,6 +114,21 @@ public actor AuthenticationActor {
         }
 
         return string
+    }
+
+    nonisolated private static func infoValue(for key: String) -> String? {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    nonisolated private static func requiredInfoValue(for key: String) -> String {
+        guard let value = infoValue(for: key) else {
+            preconditionFailure("Missing required Info.plist value for \(key)")
+        }
+        return value
     }
 }
 

--- a/XCodeWrapper/Configs/Common.xcconfig
+++ b/XCodeWrapper/Configs/Common.xcconfig
@@ -1,5 +1,6 @@
+DEVELOPMENT_TEAM = 9CJ7KG7UKQ
 APP_BUNDLE_ID = com.kyonifer.SilveranReader
 WATCH_APP_BUNDLE_ID = $(APP_BUNDLE_ID).watchkitapp
 KEYCHAIN_GROUP_SUFFIX = com.kyonifer.silveran.shared
-KEYCHAIN_SERVICE = com.kyonifer.silveranreader.storyteller
+KEYCHAIN_SERVICE = com.kyonifer.silveran.storyteller
 KEYCHAIN_ACCESS_GROUP = $(AppIdentifierPrefix)$(KEYCHAIN_GROUP_SUFFIX)

--- a/XCodeWrapper/Configs/Common.xcconfig
+++ b/XCodeWrapper/Configs/Common.xcconfig
@@ -1,0 +1,5 @@
+APP_BUNDLE_ID = com.kyonifer.SilveranReader
+WATCH_APP_BUNDLE_ID = $(APP_BUNDLE_ID).watchkitapp
+KEYCHAIN_GROUP_SUFFIX = com.kyonifer.silveran.shared
+KEYCHAIN_SERVICE = com.kyonifer.silveranreader.storyteller
+KEYCHAIN_ACCESS_GROUP = $(AppIdentifierPrefix)$(KEYCHAIN_GROUP_SUFFIX)

--- a/XCodeWrapper/Configs/Debug.xcconfig
+++ b/XCodeWrapper/Configs/Debug.xcconfig
@@ -1,0 +1,2 @@
+#include "Common.xcconfig"
+#include? "Local.xcconfig"

--- a/XCodeWrapper/Configs/Local.example.xcconfig
+++ b/XCodeWrapper/Configs/Local.example.xcconfig
@@ -4,4 +4,4 @@ DEVELOPMENT_TEAM = YOUR_TEAM_ID
 APP_BUNDLE_ID = com.example.SilveranReader
 WATCH_APP_BUNDLE_ID = $(APP_BUNDLE_ID).watchkitapp
 KEYCHAIN_GROUP_SUFFIX = com.example.silveran.shared
-KEYCHAIN_SERVICE = com.example.silveranreader.storyteller
+KEYCHAIN_SERVICE = com.example.silveran.storyteller

--- a/XCodeWrapper/Configs/Local.example.xcconfig
+++ b/XCodeWrapper/Configs/Local.example.xcconfig
@@ -1,0 +1,7 @@
+DEVELOPMENT_TEAM = YOUR_TEAM_ID
+
+// Overrides for your personal dev account's namespace/keychain details
+APP_BUNDLE_ID = com.example.SilveranReader
+WATCH_APP_BUNDLE_ID = $(APP_BUNDLE_ID).watchkitapp
+KEYCHAIN_GROUP_SUFFIX = com.example.silveran.shared
+KEYCHAIN_SERVICE = com.example.silveranreader.storyteller

--- a/XCodeWrapper/Configs/Release.xcconfig
+++ b/XCodeWrapper/Configs/Release.xcconfig
@@ -1,0 +1,2 @@
+#include "Common.xcconfig"
+#include? "Local.xcconfig"

--- a/XCodeWrapper/Info-tvOS.plist
+++ b/XCodeWrapper/Info-tvOS.plist
@@ -34,5 +34,7 @@
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Automatic</string>
 </dict>
 </plist>

--- a/XCodeWrapper/Info-tvOS.plist
+++ b/XCodeWrapper/Info-tvOS.plist
@@ -22,6 +22,10 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>KEYCHAIN_ACCESS_GROUP</key>
+	<string>$(KEYCHAIN_ACCESS_GROUP)</string>
+	<key>KEYCHAIN_SERVICE</key>
+	<string>$(KEYCHAIN_SERVICE)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.books</string>
 	<key>UIBackgroundModes</key>

--- a/XCodeWrapper/SilveranReaderIos.entitlements
+++ b/XCodeWrapper/SilveranReaderIos.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.kyonifer.silveran.shared</string>
+		<string>$(AppIdentifierPrefix)$(KEYCHAIN_GROUP_SUFFIX)</string>
 	</array>
 </dict>
 </plist>

--- a/XCodeWrapper/SilveranReaderMac.entitlements
+++ b/XCodeWrapper/SilveranReaderMac.entitlements
@@ -10,7 +10,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.kyonifer.silveran.shared</string>
+		<string>$(AppIdentifierPrefix)$(KEYCHAIN_GROUP_SUFFIX)</string>
 	</array>
 </dict>
 </plist>

--- a/XCodeWrapper/SilveranReaderTV.entitlements
+++ b/XCodeWrapper/SilveranReaderTV.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.kyonifer.silveran.shared</string>
+		<string>$(AppIdentifierPrefix)$(KEYCHAIN_GROUP_SUFFIX)</string>
 	</array>
 </dict>
 </plist>

--- a/XCodeWrapper/SilveranReaderWatch.entitlements
+++ b/XCodeWrapper/SilveranReaderWatch.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.kyonifer.silveran.shared</string>
+		<string>$(AppIdentifierPrefix)$(KEYCHAIN_GROUP_SUFFIX)</string>
 	</array>
 </dict>
 </plist>

--- a/XCodeWrapper/project.yml
+++ b/XCodeWrapper/project.yml
@@ -28,12 +28,8 @@ targets:
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderMac.entitlements
         CURRENT_PROJECT_VERSION: 1
         DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
-        GENERATE_INFOPLIST_FILE: YES
-        INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.books
-        INFOPLIST_KEY_NSLocalNetworkUsageDescription: "Silveran Reader needs local network access to connect to your Storyteller server."
-        INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
-        INFOPLIST_KEY_KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
-        INFOPLIST_KEY_KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: XCodeWrapper/Info-macOS.plist
         MARKETING_VERSION: 0.1
         PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
         #INFOPLIST_KEY_CFBundleDisplayName: Silveran Reader
@@ -42,11 +38,26 @@ targets:
         PRODUCT_NAME: Silveran Reader
         #SWIFT_UPCOMING_FEATURE_NONSENDING_NONISOLATING_BY_DEFAULT: YES
         SWIFT_VERSION: 6.2
+    info:
+      path: XCodeWrapper/Info-macOS.plist
+      properties:
+        CFBundleName: "Silveran Reader"
+        CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)"
+        CFBundleExecutable: "$(EXECUTABLE_NAME)"
+        KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
+        KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
+        LSApplicationCategoryType: "public.app-category.books"
+        NSLocalNetworkUsageDescription: "Silveran Reader needs local network access to connect to your Storyteller server."
+        ITSAppUsesNonExemptEncryption: false
     sources:
       - path: XCodeWrapper
         excludes:
           - "**/*.entitlements"
           - "**/.DS_Store"
+          - "Info-*.plist"
           - "WebResources/"
           - "Assets.xcassets/"
           - "project.yml"
@@ -137,6 +148,7 @@ targets:
         excludes:
           - "**/*.entitlements"
           - "**/.DS_Store"
+          - "Info-*.plist"
           - "WebResources/"
           - "Assets.xcassets/"
           - "project.yml"
@@ -180,17 +192,29 @@ targets:
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
         DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
-        GENERATE_INFOPLIST_FILE: YES
-        INFOPLIST_KEY_WKBackgroundModes: audio
-        INFOPLIST_KEY_WKCompanionAppBundleIdentifier: "$(APP_BUNDLE_ID)"
-        INFOPLIST_KEY_KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
-        INFOPLIST_KEY_KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: XCodeWrapper/Info-watchOS.plist
         MARKETING_VERSION: 0.1
         PRODUCT_BUNDLE_IDENTIFIER: "$(WATCH_APP_BUNDLE_ID)"
         PRODUCT_NAME: Silveran Reader
         SWIFT_VERSION: 6.2
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        INFOPLIST_KEY_CFBundleIconName: AppIcon
+    info:
+      path: XCodeWrapper/Info-watchOS.plist
+      properties:
+        CFBundleName: "Silveran Reader"
+        CFBundleDisplayName: "Silveran Reader"
+        CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)"
+        CFBundleExecutable: "$(EXECUTABLE_NAME)"
+        KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
+        KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
+        WKApplication: true
+        WKBackgroundModes:
+          - audio
+        WKCompanionAppBundleIdentifier: "$(APP_BUNDLE_ID)"
     sources:
       - path: XCodeWrapper/EntryPointStub.swift
       - path: XCodeWrapper/WatchAssets.xcassets
@@ -212,9 +236,8 @@ targets:
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
         DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
-        GENERATE_INFOPLIST_FILE: YES
-        INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UIUserInterfaceStyle: Automatic
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: XCodeWrapper/Info-tvOS.plist
         MARKETING_VERSION: 0.1
         PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
         PRODUCT_NAME: Silveran Reader
@@ -234,6 +257,7 @@ targets:
         KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
         LSApplicationCategoryType: "public.app-category.books"
         UILaunchScreen: {}
+        UIUserInterfaceStyle: Automatic
         UIBackgroundModes:
           - audio
         ITSAppUsesNonExemptEncryption: false

--- a/XCodeWrapper/project.yml
+++ b/XCodeWrapper/project.yml
@@ -18,19 +18,24 @@ targets:
     platform: macOS
     supportedDestinations: [macOS]
     productName: "Silveran Reader"
+    configFiles:
+      Debug: XCodeWrapper/Configs/Debug.xcconfig
+      Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
         MACOSX_DEPLOYMENT_TARGET: 15.0
         ENABLE_HARDENED_RUNTIME: YES
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderMac.entitlements
         CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: 9CJ7KG7UKQ
+        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.books
         INFOPLIST_KEY_NSLocalNetworkUsageDescription: "Silveran Reader needs local network access to connect to your Storyteller server."
         INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
+        INFOPLIST_KEY_KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
+        INFOPLIST_KEY_KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
         MARKETING_VERSION: 0.1
-        PRODUCT_BUNDLE_IDENTIFIER: com.kyonifer.SilveranReader
+        PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
         #INFOPLIST_KEY_CFBundleDisplayName: Silveran Reader
         #INFOPLIST_KEY_CFBundleName: Silveran Reader
         # Unknown why this redundant definition is needed for XCode to honor the app name
@@ -74,17 +79,20 @@ targets:
     type: application
     platform: iOS
     productName: "Silveran Reader"
+    configFiles:
+      Debug: XCodeWrapper/Configs/Debug.xcconfig
+      Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
         IPHONEOS_DEPLOYMENT_TARGET: 17.0
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderIos.entitlements
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: 9CJ7KG7UKQ
+        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: XCodeWrapper/Info-iOS.plist
         MARKETING_VERSION: 0.1
-        PRODUCT_BUNDLE_IDENTIFIER: com.kyonifer.SilveranReader
+        PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
         #INFOPLIST_KEY_CFBundleDisplayName: Silveran Reader
         #INFOPLIST_KEY_CFBundleName: Silveran Reader
         PRODUCT_NAME: Silveran Reader
@@ -101,6 +109,8 @@ targets:
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)"
         CFBundleExecutable: "$(EXECUTABLE_NAME)"
+        KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
+        KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
         LSApplicationCategoryType: "public.app-category.books"
         NSLocalNetworkUsageDescription: "Silveran Reader needs local network access to connect to your Storyteller server."
         UILaunchScreen: {}
@@ -160,18 +170,23 @@ targets:
     type: application
     platform: watchOS
     productName: "Silveran Reader"
+    configFiles:
+      Debug: XCodeWrapper/Configs/Debug.xcconfig
+      Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
         WATCHOS_DEPLOYMENT_TARGET: 10.0
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderWatch.entitlements
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: 9CJ7KG7UKQ
+        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_WKBackgroundModes: audio
-        INFOPLIST_KEY_WKCompanionAppBundleIdentifier: com.kyonifer.SilveranReader
+        INFOPLIST_KEY_WKCompanionAppBundleIdentifier: "$(APP_BUNDLE_ID)"
+        INFOPLIST_KEY_KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
+        INFOPLIST_KEY_KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
         MARKETING_VERSION: 0.1
-        PRODUCT_BUNDLE_IDENTIFIER: com.kyonifer.SilveranReader.watchkitapp
+        PRODUCT_BUNDLE_IDENTIFIER: "$(WATCH_APP_BUNDLE_ID)"
         PRODUCT_NAME: Silveran Reader
         SWIFT_VERSION: 6.2
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
@@ -187,18 +202,21 @@ targets:
     type: application
     platform: tvOS
     productName: "Silveran Reader"
+    configFiles:
+      Debug: XCodeWrapper/Configs/Debug.xcconfig
+      Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
         TVOS_DEPLOYMENT_TARGET: 17.0
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderTV.entitlements
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: 9CJ7KG7UKQ
+        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UIUserInterfaceStyle: Automatic
         MARKETING_VERSION: 0.1
-        PRODUCT_BUNDLE_IDENTIFIER: com.kyonifer.SilveranReader
+        PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
         PRODUCT_NAME: Silveran Reader
         SWIFT_VERSION: 6.2
         ASSETCATALOG_COMPILER_APPICON_NAME: "App Icon"
@@ -212,6 +230,8 @@ targets:
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)"
         CFBundleExecutable: "$(EXECUTABLE_NAME)"
+        KEYCHAIN_ACCESS_GROUP: "$(KEYCHAIN_ACCESS_GROUP)"
+        KEYCHAIN_SERVICE: "$(KEYCHAIN_SERVICE)"
         LSApplicationCategoryType: "public.app-category.books"
         UILaunchScreen: {}
         UIBackgroundModes:

--- a/XCodeWrapper/project.yml
+++ b/XCodeWrapper/project.yml
@@ -12,32 +12,39 @@ configs:
 packages:
   SilveranKit:
     path: SilveranKit
-targets:
-  Silveran Reader (macOS):
+targetTemplates:
+  appBase:
     type: application
-    platform: macOS
-    supportedDestinations: [macOS]
     productName: "Silveran Reader"
     configFiles:
       Debug: XCodeWrapper/Configs/Debug.xcconfig
       Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
-        MACOSX_DEPLOYMENT_TARGET: 15.0
-        ENABLE_HARDENED_RUNTIME: YES
-        CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderMac.entitlements
         CURRENT_PROJECT_VERSION: 1
         DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
         GENERATE_INFOPLIST_FILE: NO
-        INFOPLIST_FILE: XCodeWrapper/Info-macOS.plist
         MARKETING_VERSION: 0.1
+        PRODUCT_NAME: Silveran Reader
+        SWIFT_VERSION: 6.2
+
+targets:
+  Silveran Reader (macOS):
+    templates:
+      - appBase
+    platform: macOS
+    supportedDestinations: [macOS]
+    settings:
+      base:
+        MACOSX_DEPLOYMENT_TARGET: 15.0
+        ENABLE_HARDENED_RUNTIME: YES
+        CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderMac.entitlements
+        INFOPLIST_FILE: XCodeWrapper/Info-macOS.plist
         PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
         #INFOPLIST_KEY_CFBundleDisplayName: Silveran Reader
         #INFOPLIST_KEY_CFBundleName: Silveran Reader
         # Unknown why this redundant definition is needed for XCode to honor the app name
-        PRODUCT_NAME: Silveran Reader
         #SWIFT_UPCOMING_FEATURE_NONSENDING_NONISOLATING_BY_DEFAULT: YES
-        SWIFT_VERSION: 6.2
     info:
       path: XCodeWrapper/Info-macOS.plist
       properties:
@@ -54,14 +61,8 @@ targets:
         ITSAppUsesNonExemptEncryption: false
     sources:
       - path: XCodeWrapper
-        excludes:
-          - "**/*.entitlements"
-          - "**/.DS_Store"
-          - "Info-*.plist"
-          - "WebResources/"
-          - "Assets.xcassets/"
-          - "project.yml"
-          - "PrivacyInfo.xcprivacy"
+        includes:
+          - "**/*.swift"
       - path: XCodeWrapper/Assets.xcassets
         type: assetcatalog
       - path: XCodeWrapper/PrivacyInfo.xcprivacy
@@ -87,29 +88,20 @@ targets:
         product: SilveranKitMacApp
 
   Silveran Reader (iOS):
-    type: application
+    templates:
+      - appBase
     platform: iOS
-    productName: "Silveran Reader"
-    configFiles:
-      Debug: XCodeWrapper/Configs/Debug.xcconfig
-      Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
         IPHONEOS_DEPLOYMENT_TARGET: 17.0
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderIos.entitlements
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
-        GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: XCodeWrapper/Info-iOS.plist
-        MARKETING_VERSION: 0.1
         PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
         #INFOPLIST_KEY_CFBundleDisplayName: Silveran Reader
         #INFOPLIST_KEY_CFBundleName: Silveran Reader
-        PRODUCT_NAME: Silveran Reader
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: NO
         #SWIFT_UPCOMING_FEATURE_NONSENDING_NONISOLATING_BY_DEFAULT: YES
-        SWIFT_VERSION: 6.2
     info:
       path: XCodeWrapper/Info-iOS.plist
       properties:
@@ -145,14 +137,8 @@ targets:
                 UISceneDelegateClassName: SilveranKitiOSApp.CarPlaySceneDelegate
     sources:
       - path: XCodeWrapper
-        excludes:
-          - "**/*.entitlements"
-          - "**/.DS_Store"
-          - "Info-*.plist"
-          - "WebResources/"
-          - "Assets.xcassets/"
-          - "project.yml"
-          - "PrivacyInfo.xcprivacy"
+        includes:
+          - "**/*.swift"
       - path: XCodeWrapper/Assets.xcassets
         type: assetcatalog
       - path: XCodeWrapper/PrivacyInfo.xcprivacy
@@ -179,25 +165,16 @@ targets:
       - target: "Silveran Reader (watchOS)"
         embed: true
   Silveran Reader (watchOS):
-    type: application
+    templates:
+      - appBase
     platform: watchOS
-    productName: "Silveran Reader"
-    configFiles:
-      Debug: XCodeWrapper/Configs/Debug.xcconfig
-      Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
         WATCHOS_DEPLOYMENT_TARGET: 10.0
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderWatch.entitlements
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
-        GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: XCodeWrapper/Info-watchOS.plist
-        MARKETING_VERSION: 0.1
         PRODUCT_BUNDLE_IDENTIFIER: "$(WATCH_APP_BUNDLE_ID)"
-        PRODUCT_NAME: Silveran Reader
-        SWIFT_VERSION: 6.2
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
     info:
       path: XCodeWrapper/Info-watchOS.plist
@@ -223,25 +200,16 @@ targets:
       - package: SilveranKit
         product: SilveranKitWatchApp
   Silveran Reader (tvOS):
-    type: application
+    templates:
+      - appBase
     platform: tvOS
-    productName: "Silveran Reader"
-    configFiles:
-      Debug: XCodeWrapper/Configs/Debug.xcconfig
-      Release: XCodeWrapper/Configs/Release.xcconfig
     settings:
       base:
         TVOS_DEPLOYMENT_TARGET: 17.0
         CODE_SIGN_ENTITLEMENTS: XCodeWrapper/SilveranReaderTV.entitlements
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: "$(DEVELOPMENT_TEAM)"
-        GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: XCodeWrapper/Info-tvOS.plist
-        MARKETING_VERSION: 0.1
         PRODUCT_BUNDLE_IDENTIFIER: "$(APP_BUNDLE_ID)"
-        PRODUCT_NAME: Silveran Reader
-        SWIFT_VERSION: 6.2
         ASSETCATALOG_COMPILER_APPICON_NAME: "App Icon"
     info:
       path: XCodeWrapper/Info-tvOS.plist


### PR DESCRIPTION
Currently, Silveran uses hard-coded development account related values within `project.yml`, and the `AuthenticationActor` for accessing keychain related data. This PR refactors the Xcode project generation to use native Xcode config files (xcconfig), standardizes `Info.plist` generation among app targets, and cleans up the authentication actor to dynamically use the current keychain access group instead of a hard coded string.

For new devs to the project, we introduce a new `Local.example.xcconfig` that can be copied, and filled out with their personal account values. For your @kyonifer , you don't technically need to do so, since if a `Local.xcconfig` is not present, it'll default to using your existing values (defined in `Common.xcconfig`).

Verification:
- `scripts/genxproj` succeeds
- Successfully tested macOS/iOS builds on device, and confirmed that keychain values are persisted among app restarts