### PR TITLE
Add separate read-aloud and listening speeds

### DIFF
--- a/SilveranKit/Sources/AppleKit/MobileDesktop/PlaybackRatePolicy.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/PlaybackRatePolicy.swift
@@ -1,0 +1,35 @@
+#if os(iOS) || os(macOS)
+import Foundation
+import SilveranKit
+
+enum PlaybackRatePolicy {
+    static let minimumRate = kMinimumPlaybackSpeed
+    static let maximumRate = kMaximumPlaybackSpeed
+    static let sliderStep = PlaybackSpeedPolicy.sliderStep
+    static let presetStep = PlaybackSpeedPolicy.presetStep
+    static let presetRates = PlaybackSpeedPolicy.presetRates
+
+    static func formattedCurrentRate(_ rate: Double) -> String {
+        String(format: "%.2fx", rate)
+    }
+
+    static func formattedPresetRate(_ rate: Double) -> String {
+        if rate == rate.rounded() {
+            return String(format: "%.1fx", rate)
+        }
+        let formatted = String(format: "%.2f", rate)
+        if formatted.hasSuffix("0") {
+            return String(format: "%.1fx", rate)
+        }
+        return "\(formatted)x"
+    }
+
+    static func activeRole(
+        isReaderSceneActive: Bool,
+        isPlayerExpanded: Bool,
+    ) -> PlaybackSpeedRole {
+        isReaderSceneActive && !isPlayerExpanded ? .readaloud : .listening
+    }
+}
+
+#endif

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/PlaybackSpeedControls.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/PlaybackSpeedControls.swift
@@ -1,0 +1,27 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+public enum PlaybackSpeedControls {
+    case single(currentRate: Double, rate: Binding<Double>)
+    case dual(
+        currentRate: Double,
+        listeningRate: Binding<Double>,
+        readaloudRate: Binding<Double>,
+    )
+
+    public var currentRate: Double {
+        switch self {
+            case .single(let currentRate, _), .dual(let currentRate, _, _):
+                currentRate
+        }
+    }
+
+    var isDual: Bool {
+        if case .dual = self {
+            return true
+        }
+        return false
+    }
+}
+
+#endif

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/SettingsViewModel.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/SettingsViewModel.swift
@@ -27,10 +27,22 @@ public final class SettingsViewModel {
     public var singleColumnMode: Bool = kDefaultSingleColumnMode
     public var scrollingMode: Bool = kDefaultScrollingMode
 
-    public var defaultPlaybackSpeed: Double = kDefaultPlaybackSpeed
-    public var defaultVolume: Double = kDefaultVolume
-    public var statsExpanded: Bool = kDefaultStatsExpanded
-    public var lockViewToAudio: Bool = kDefaultLockViewToAudio
+    public private(set) var playback = SilveranGlobalConfig.Playback()
+
+    public var defaultPlaybackSpeed: Double { playback.defaultPlaybackSpeed }
+    public var readaloudPlaybackSpeed: Double { playback.readaloudPlaybackSpeed }
+    public var defaultVolume: Double {
+        get { playback.defaultVolume }
+        set { playback.defaultVolume = newValue }
+    }
+    public var statsExpanded: Bool {
+        get { playback.statsExpanded }
+        set { playback.statsExpanded = newValue }
+    }
+    public var lockViewToAudio: Bool {
+        get { playback.lockViewToAudio }
+        set { playback.lockViewToAudio = newValue }
+    }
 
     public var enableReadingBar: Bool = kDefaultReadingBarEnabled
     #if os(iOS)
@@ -87,6 +99,7 @@ public final class SettingsViewModel {
     public var isLoaded: Bool = false
 
     @ObservationIgnored private var observerID: UUID?
+    @ObservationIgnored private var initialLoadTask: Task<Void, Never>?
     @ObservationIgnored private var saveTask: Task<Void, Never>?
 
     public var readingBarConfig: SilveranGlobalConfig.ReadingBar {
@@ -129,13 +142,15 @@ public final class SettingsViewModel {
     }
 
     public init() {
-        Task {
-            await loadSettings()
-            await registerObserver()
+        initialLoadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.loadSettings()
+            await self.registerObserver()
         }
     }
 
     deinit {
+        initialLoadTask?.cancel()
         if let id = observerID {
             Task {
                 await SettingsActor.shared.removeObserver(id: id)
@@ -145,6 +160,7 @@ public final class SettingsViewModel {
 
     private func loadSettings() async {
         let config = await SettingsActor.shared.config
+        playback = config.playback
 
         fontSize = config.reading.fontSize
         fontFamily = config.reading.fontFamily
@@ -162,11 +178,6 @@ public final class SettingsViewModel {
         enableMarginClickNavigation = config.reading.enableMarginClickNavigation
         singleColumnMode = config.reading.singleColumnMode
         scrollingMode = config.reading.scrollingMode
-
-        defaultPlaybackSpeed = config.playback.defaultPlaybackSpeed
-        defaultVolume = config.playback.defaultVolume
-        statsExpanded = config.playback.statsExpanded
-        lockViewToAudio = config.playback.lockViewToAudio
 
         enableReadingBar = config.readingBar.enabled
         showPlayerControls = config.readingBar.showPlayerControls
@@ -366,6 +377,26 @@ public final class SettingsViewModel {
         }
     }
 
+    public func waitUntilLoaded() async {
+        await initialLoadTask?.value
+    }
+
+    public func updatePlaybackSpeed(_ speed: Double, for role: PlaybackSpeedRole) {
+        playback.updatePlaybackSpeed(speed, for: role)
+        save()
+    }
+
+    func playbackSpeedBinding(for role: PlaybackSpeedRole) -> Binding<Double> {
+        Binding(
+            get: { [weak self] in
+                self?.playback.playbackSpeed(for: role) ?? kDefaultPlaybackSpeed
+            },
+            set: { [weak self] speed in
+                self?.updatePlaybackSpeed(speed, for: role)
+            },
+        )
+    }
+
     private func persistNow() async throws {
         try await SettingsActor.shared.updateConfig(
             fontSize: fontSize,
@@ -384,10 +415,7 @@ public final class SettingsViewModel {
             enableMarginClickNavigation: enableMarginClickNavigation,
             singleColumnMode: singleColumnMode,
             scrollingMode: scrollingMode,
-            defaultPlaybackSpeed: defaultPlaybackSpeed,
-            defaultVolume: defaultVolume,
-            statsExpanded: statsExpanded,
-            lockViewToAudio: lockViewToAudio,
+            playback: playback,
             enableReadingBar: enableReadingBar,
             showPlayerControls: showPlayerControls,
             showProgressBar: showProgressBar,

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/AudiobookPlayerView.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/AudiobookPlayerView.swift
@@ -15,13 +15,11 @@ public struct AudiobookPlayerView: View {
 
     @State private var chapterProgress: Double = 0.0
     @State private var isPlaying = false
-    @State private var playbackRate: Double = 1.0
-    @State private var volume: Double = 1.0
+    @State private var settingsVM = SettingsViewModel()
     @State private var sleepTimerActive = false
     @State private var sleepTimerRemaining: TimeInterval? = nil
     @State private var sleepTimerType: SleepTimerType? = nil
     @State private var sleepTimer: Timer? = nil
-    @State private var settingsInitialized = false
 
     @State private var metadata: AudiobookMetadata?
     @State private var currentChapterTitle: String = "Loading..."
@@ -88,16 +86,8 @@ public struct AudiobookPlayerView: View {
                 }
                 #endif
 
-                if !settingsInitialized {
-                    Task { @MainActor in
-                        let config = await SettingsActor.shared.config
-                        playbackRate = config.playback.defaultPlaybackSpeed
-                        volume = config.playback.defaultVolume
-                        settingsInitialized = true
-                    }
-                }
-
                 Task { @MainActor in
+                    await settingsVM.waitUntilLoaded()
                     await loadAudiobook()
                 }
             }
@@ -142,32 +132,18 @@ public struct AudiobookPlayerView: View {
                     await AudiobookActor.shared.cleanup()
                 }
             }
-            .onChange(of: playbackRate) { _, newValue in
-                if settingsInitialized {
+            .onChange(of: settingsVM.defaultVolume) { _, newValue in
+                if settingsVM.isLoaded {
                     Task {
-                        await AudiobookActor.shared.setPlaybackRate(newValue)
-                        do {
-                            try await SettingsActor.shared.updateConfig(
-                                defaultPlaybackSpeed: newValue
-                            )
-                        } catch {
-                            debugLog(
-                                "[AudiobookPlayerView] Failed to auto-save playback rate: \(error)"
-                            )
-                        }
+                        await AudiobookActor.shared.setVolume(newValue)
+                        settingsVM.save()
                     }
                 }
             }
-            .onChange(of: volume) { _, newValue in
-                if settingsInitialized {
-                    Task {
-                        await AudiobookActor.shared.setVolume(newValue)
-                        do {
-                            try await SettingsActor.shared.updateConfig(defaultVolume: newValue)
-                        } catch {
-                            debugLog("[AudiobookPlayerView] Failed to auto-save volume: \(error)")
-                        }
-                    }
+            .onChange(of: settingsVM.defaultPlaybackSpeed) { _, newValue in
+                guard settingsVM.isLoaded else { return }
+                Task {
+                    await AudiobookActor.shared.setPlaybackRate(newValue)
                 }
             }
             #if os(iOS)
@@ -203,6 +179,17 @@ public struct AudiobookPlayerView: View {
     private var readingSidebarView: some View {
         let bookTitle = bookData?.metadata.title ?? "Unknown Book"
         let bookAuthor = bookData?.metadata.authors?.first?.name ?? "Unknown Author"
+        let playbackSpeeds: PlaybackSpeedControls =
+            showsDualPlaybackSpeeds
+            ? .dual(
+                currentRate: settingsVM.defaultPlaybackSpeed,
+                listeningRate: settingsVM.playbackSpeedBinding(for: .listening),
+                readaloudRate: settingsVM.playbackSpeedBinding(for: .readaloud),
+            )
+            : .single(
+                currentRate: settingsVM.defaultPlaybackSpeed,
+                rate: settingsVM.playbackSpeedBinding(for: .listening),
+            )
 
         return ReadingSidebarView(
             bookData: bookData,
@@ -214,8 +201,7 @@ public struct AudiobookPlayerView: View {
                 ebookCoverArt: bookData?.ebookCoverArt,
                 chapterDuration: chapterDuration,
                 totalRemaining: totalRemaining,
-                playbackRate: playbackRate,
-                volume: volume,
+                volume: settingsVM.defaultVolume,
                 isPlaying: isPlaying,
                 sleepTimerActive: sleepTimerActive,
                 sleepTimerRemaining: sleepTimerRemaining,
@@ -267,11 +253,9 @@ public struct AudiobookPlayerView: View {
             onNextChapter: {
                 handleNextChapter()
             },
-            onPlaybackRateChange: { rate in
-                playbackRate = rate
-            },
+            playbackSpeeds: playbackSpeeds,
             onVolumeChange: { newVolume in
-                volume = newVolume
+                settingsVM.defaultVolume = newVolume
             },
             onSleepTimerStart: { duration, type in
                 startSleepTimer(duration: duration, type: type)
@@ -293,6 +277,14 @@ public struct AudiobookPlayerView: View {
             },
             seekWhileDragging: false,
         )
+    }
+
+    private var showsDualPlaybackSpeeds: Bool {
+        #if os(iOS)
+        bookData?.category == .synced || bookData?.metadata.hasAvailableReadaloud == true
+        #else
+        false
+        #endif
     }
 
     private func loadAudiobook() async {
@@ -326,8 +318,8 @@ public struct AudiobookPlayerView: View {
 
             try await AudiobookActor.shared.preparePlayer()
 
-            await AudiobookActor.shared.setPlaybackRate(playbackRate)
-            await AudiobookActor.shared.setVolume(volume)
+            await AudiobookActor.shared.setPlaybackRate(settingsVM.defaultPlaybackSpeed)
+            await AudiobookActor.shared.setVolume(settingsVM.defaultVolume)
 
             if let psaProgress = await ProgressSyncActor.shared.getBookProgress(
                 for: bookData.metadata.id

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/DraggableAudioCard.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/DraggableAudioCard.swift
@@ -16,7 +16,7 @@ struct DraggableAudioCard<FullContent: View>: View {
     let chapterElapsedSeconds: TimeInterval?
     let chapterTotalSeconds: TimeInterval?
     let bookTimeRemaining: TimeInterval?
-    let playbackRate: Double
+    let playbackSpeeds: PlaybackSpeedControls
     let hasAudioNarration: Bool
     let chapters: [ChapterItem]
     let selectedChapterHref: String?
@@ -32,12 +32,12 @@ struct DraggableAudioCard<FullContent: View>: View {
     let onPrevChapter: () -> Void
     let onNextChapter: () -> Void
     let onProgressSeek: ((Double) -> Void)?
-    let onPlaybackRateChange: (Double) -> Void
     let onChapterSelected: (ChapterItem) -> Void
     let onSleepTimerStart: (TimeInterval?, SleepTimerType) -> Void
     let onSleepTimerCancel: () -> Void
     let onDismiss: () -> Void
     let onComicScrubberVisibilityChange: (Bool) -> Void
+    let onExpandedChange: (Bool) -> Void
     @ViewBuilder let fullContent: () -> FullContent
 
     enum CardState {
@@ -57,17 +57,19 @@ struct DraggableAudioCard<FullContent: View>: View {
     private let expandedFraction: CGFloat = 1.0
     private let scrubberFraction: CGFloat = 0.28
     private let dragThreshold: CGFloat = 40
+    private let minimumCompactBottomInset: CGFloat = 34
 
     var body: some View {
         GeometryReader { geometry in
             let screenHeight = geometry.size.height
             let safeAreaBottom = geometry.safeAreaInsets.bottom
+            let compactBottomInset = max(safeAreaBottom, minimumCompactBottomInset)
             let expandedHeight = screenHeight * expandedFraction
             let scrubberHeight = max(screenHeight * scrubberFraction, 170)
 
             let targetHeight: CGFloat =
                 switch cardState {
-                    case .compact: compactHeight + safeAreaBottom
+                    case .compact: compactHeight + compactBottomInset
                     case .scrubber: scrubberHeight
                     case .expanded: expandedHeight
                 }
@@ -99,12 +101,15 @@ struct DraggableAudioCard<FullContent: View>: View {
 
                         if cardState == .compact && hasAudioNarration && showMiniPlayerStats {
                             compactStatsRow
-                                .frame(height: safeAreaBottom)
+                                .frame(height: compactBottomInset)
                         } else if cardState == .scrubber {
                             Color.clear
                                 .frame(height: safeAreaBottom)
                         } else {
-                            Spacer(minLength: safeAreaBottom)
+                            Spacer(
+                                minLength: cardState == .compact
+                                    ? compactBottomInset : safeAreaBottom
+                            )
                         }
                     }
                     .overlay(alignment: .top) {
@@ -182,20 +187,24 @@ struct DraggableAudioCard<FullContent: View>: View {
             onComicScrubberVisibilityChange(
                 isPresented && supportsComicScrubber && newValue == .scrubber
             )
+            onExpandedChange(isPresented && newValue == .expanded)
         }
         .onChange(of: isPresented) { _, newValue in
             onComicScrubberVisibilityChange(
                 newValue && supportsComicScrubber && cardState == .scrubber
             )
+            onExpandedChange(newValue && cardState == .expanded)
         }
         .onAppear {
             sliderValue = chapterProgress
             onComicScrubberVisibilityChange(
                 isPresented && supportsComicScrubber && cardState == .scrubber
             )
+            onExpandedChange(isPresented && cardState == .expanded)
         }
         .onDisappear {
             onComicScrubberVisibilityChange(false)
+            onExpandedChange(false)
         }
     }
 
@@ -267,8 +276,7 @@ struct DraggableAudioCard<FullContent: View>: View {
             if hasAudioNarration {
                 HStack(spacing: 15) {
                     PlaybackRateButton(
-                        currentRate: playbackRate,
-                        onRateChange: onPlaybackRateChange,
+                        playbackSpeeds: playbackSpeeds,
                         showLabel: true,
                         buttonSize: showMiniPlayerStats ? 32 : 36,
                         showBackground: false,
@@ -403,11 +411,11 @@ struct DraggableAudioCard<FullContent: View>: View {
 
     private var chapterTimeRemaining: TimeInterval? {
         guard let elapsed = chapterElapsedSeconds, let total = chapterTotalSeconds,
-            playbackRate > 0
+            playbackSpeeds.currentRate > 0
         else {
             return nil
         }
-        return max(0, total - elapsed) / playbackRate
+        return max(0, total - elapsed) / playbackSpeeds.currentRate
     }
 
     private func handleDragEnd(translation: CGFloat, velocity: CGFloat, screenHeight: CGFloat) {

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/EbookPlayerView.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/EbookPlayerView.swift
@@ -169,6 +169,10 @@ public struct EbookPlayerView: View {
         .onChange(of: scenePhase) { _, newPhase in
             viewModel.handleScenePhaseChange(newPhase)
         }
+        .onChange(of: viewModel.activePlaybackRate) { _, _ in
+            guard viewModel.settingsVM.isLoaded else { return }
+            viewModel.applyActivePlayback()
+        }
         .onChange(of: viewModel.settingsVM.highlightColorsHash) { _, _ in
             Task { await viewModel.refreshHighlightColors() }
         }
@@ -550,7 +554,7 @@ public struct EbookPlayerView: View {
             if viewModel.isTopBarVisible {
                 EbookPlayerTopToolbar(
                     hasAudioNarration: viewModel.hasAudioNarration,
-                    playbackSpeed: viewModel.settingsVM.defaultPlaybackSpeed,
+                    playbackSpeed: viewModel.settingsVM.readaloudPlaybackSpeed,
                     chapters: viewModel.chapterList,
                     selectedChapterId: viewModel.selectedChapterHref,
                     isSynced: viewModel.settingsVM.lockViewToAudio,
@@ -621,7 +625,7 @@ public struct EbookPlayerView: View {
                     readingBarConfig: viewModel.settingsVM.readingBarConfig,
                     progressData: progressData,
                     isPlaying: mom?.isPlaying ?? false,
-                    playbackRate: mom?.playbackRate ?? viewModel.settingsVM.defaultPlaybackSpeed,
+                    playbackRate: mom?.playbackRate ?? viewModel.settingsVM.readaloudPlaybackSpeed,
                     isLightBackground: isLight,
                     backgroundColor: readerBackgroundColor,
                     chapterProgress: viewModel.chapterProgressBinding,
@@ -690,7 +694,11 @@ public struct EbookPlayerView: View {
             chapterElapsedSeconds: mom?.chapterElapsedSeconds,
             chapterTotalSeconds: mom?.chapterTotalSeconds,
             bookTimeRemaining: mom?.bookTimeRemaining,
-            playbackRate: mom?.playbackRate ?? viewModel.settingsVM.defaultPlaybackSpeed,
+            playbackSpeeds: .dual(
+                currentRate: mom?.playbackRate ?? viewModel.settingsVM.readaloudPlaybackSpeed,
+                listeningRate: viewModel.settingsVM.playbackSpeedBinding(for: .listening),
+                readaloudRate: viewModel.settingsVM.playbackSpeedBinding(for: .readaloud),
+            ),
             hasAudioNarration: viewModel.hasAudioNarration,
             chapters: viewModel.chapterList,
             selectedChapterHref: viewModel.selectedChapterHref,
@@ -715,7 +723,6 @@ public struct EbookPlayerView: View {
                 viewModel.handleNextChapter()
             },
             onProgressSeek: viewModel.handleProgressSeek,
-            onPlaybackRateChange: viewModel.handlePlaybackRateChange,
             onChapterSelected: viewModel.handleChapterSelection,
             onSleepTimerStart: viewModel.handleSleepTimerStart,
             onSleepTimerCancel: viewModel.handleSleepTimerCancel,
@@ -725,6 +732,7 @@ public struct EbookPlayerView: View {
             onComicScrubberVisibilityChange: { visible in
                 isComicScrubberVisible = visible
             },
+            onExpandedChange: viewModel.handleAudioPlayerExpandedChange,
             fullContent: {
                 audiobookSidebar()
             },
@@ -780,6 +788,19 @@ public struct EbookPlayerView: View {
 
         let readingMode: ReadingMode = viewModel.bookData?.category == .ebook ? .ebook : .readaloud
 
+        #if os(macOS)
+        let playbackSpeeds: PlaybackSpeedControls = .single(
+            currentRate: mom?.playbackRate ?? viewModel.settingsVM.readaloudPlaybackSpeed,
+            rate: viewModel.settingsVM.playbackSpeedBinding(for: .readaloud),
+        )
+        #else
+        let playbackSpeeds: PlaybackSpeedControls = .dual(
+            currentRate: mom?.playbackRate ?? viewModel.settingsVM.readaloudPlaybackSpeed,
+            listeningRate: viewModel.settingsVM.playbackSpeedBinding(for: .listening),
+            readaloudRate: viewModel.settingsVM.playbackSpeedBinding(for: .readaloud),
+        )
+        #endif
+
         let progressData = ProgressData(
             chapterLabel: currentChapterTitle,
             chapterCurrentPage: pm?.chapterCurrentPage,
@@ -801,7 +822,6 @@ public struct EbookPlayerView: View {
                 ebookCoverArt: viewModel.bookData?.ebookCoverArt,
                 chapterDuration: chapterDuration,
                 totalRemaining: totalRemaining,
-                playbackRate: mom?.playbackRate ?? viewModel.settingsVM.defaultPlaybackSpeed,
                 volume: mom?.volume ?? viewModel.settingsVM.defaultVolume,
                 isPlaying: mom?.isPlaying ?? false,
                 sleepTimerActive: mom?.sleepTimerActive ?? false,
@@ -831,9 +851,7 @@ public struct EbookPlayerView: View {
             onNextChapter: {
                 viewModel.handleNextChapter()
             },
-            onPlaybackRateChange: { rate in
-                viewModel.handlePlaybackRateChange(rate)
-            },
+            playbackSpeeds: playbackSpeeds,
             onVolumeChange: { newVolume in
                 viewModel.handleVolumeChange(newVolume)
             },

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/EbookPlayerViewModel.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/EbookPlayerViewModel.swift
@@ -98,6 +98,8 @@ class EbookPlayerViewModel {
     var isTopBarVisible = true
     var collapseCardTrigger = 0
     #endif
+    private var isAudioPlayerExpanded = false
+    private var isReaderSceneActive = true
     var showCustomizePopover = false
     var commsBridge: WebViewCommsBridge? = nil
     var playbackProgressMessage: Any? = nil
@@ -328,16 +330,38 @@ class EbookPlayerViewModel {
         progressManager?.handleUserChapterSelected(currentIndex + 1)
     }
 
-    func handlePlaybackRateChange(_ rate: Double) {
-        debugLog("[EbookPlayerViewModel] Received playback rate change to \(rate)")
-        settingsVM.defaultPlaybackSpeed = rate
-        mediaOverlayManager?.setPlaybackRate(rate)
+    func handleAudioPlayerExpandedChange(_ isExpanded: Bool) {
+        guard isAudioPlayerExpanded != isExpanded else { return }
+        isAudioPlayerExpanded = isExpanded
+        applyActivePlayback()
+    }
 
-        Task { @MainActor in
-            do {
-                try await settingsVM.save()
-            } catch {
-                debugLog("[EbookPlayerViewModel] Failed to save playback rate: \(error)")
+    private var activePlaybackRole: PlaybackSpeedRole {
+        #if os(macOS)
+        .readaloud
+        #else
+        PlaybackRatePolicy.activeRole(
+            isReaderSceneActive: isReaderSceneActive,
+            isPlayerExpanded: isAudioPlayerExpanded,
+        )
+        #endif
+    }
+
+    var activePlaybackRate: Double {
+        settingsVM.playback.playbackSpeed(for: activePlaybackRole)
+    }
+
+    func applyActivePlayback() {
+        let role = activePlaybackRole
+        let rate = settingsVM.playback.playbackSpeed(for: role)
+        debugLog(
+            "[EbookPlayerViewModel] Applying \(role == .readaloud ? "read-aloud" : "listening") rate \(rate)"
+        )
+        if let mediaOverlayManager {
+            mediaOverlayManager.setPlaybackRate(rate)
+        } else if bookData?.metadata.id != nil {
+            Task {
+                await SMILPlayerActor.shared.setPlaybackRate(rate)
             }
         }
     }
@@ -346,14 +370,7 @@ class EbookPlayerViewModel {
         debugLog("[EbookPlayerViewModel] Received volume change to \(newVolume)")
         settingsVM.defaultVolume = newVolume
         mediaOverlayManager?.setVolume(newVolume)
-
-        Task { @MainActor in
-            do {
-                try await settingsVM.save()
-            } catch {
-                debugLog("[EbookPlayerViewModel] Failed to save volume: \(error)")
-            }
-        }
+        settingsVM.save()
     }
 
     func handleSleepTimerStart(_ duration: TimeInterval?, _ type: SleepTimerType) {
@@ -410,6 +427,10 @@ class EbookPlayerViewModel {
             "[EbookPlayerViewModel] App backgrounding - syncing progress (audio continues in background)"
         )
 
+        #if os(iOS)
+        isReaderSceneActive = false
+        applyActivePlayback()
+        #endif
         await progressManager?.syncProgressToServer(reason: .appBackgrounding)
 
         debugLog("[EbookPlayerViewModel] Background sync complete")
@@ -597,6 +618,7 @@ class EbookPlayerViewModel {
             let nativeStructure = await SMILPlayerActor.shared.getBookStructure()
             self.bookStructure = nativeStructure
             self.tocEntries = await SMILPlayerActor.shared.getTocEntries()
+            await SMILPlayerActor.shared.setPlaybackRate(activePlaybackRate)
             debugLog("[EbookPlayerViewModel] Joined session with \(nativeStructure.count) sections")
             return
         }
@@ -619,7 +641,7 @@ class EbookPlayerViewModel {
                 title: bookData?.metadata.title,
                 author: bookData?.metadata.authors?.first?.name,
             )
-            await SMILPlayerActor.shared.setPlaybackRate(settingsVM.defaultPlaybackSpeed)
+            await SMILPlayerActor.shared.setPlaybackRate(activePlaybackRate)
             await SMILPlayerActor.shared.setVolume(settingsVM.defaultVolume)
 
             let nativeStructure = await SMILPlayerActor.shared.getBookStructure()
@@ -727,6 +749,10 @@ class EbookPlayerViewModel {
     func handleScenePhaseChange(_ phase: ScenePhase) {
         switch phase {
             case .active:
+                #if os(iOS)
+                isReaderSceneActive = true
+                applyActivePlayback()
+                #endif
                 Task { @MainActor in
                     await progressManager?.handleResume()
 
@@ -746,6 +772,10 @@ class EbookPlayerViewModel {
                 }
             case .background:
                 debugLog("[EbookPlayerViewModel] Entering background - audio continues natively")
+                #if os(iOS)
+                isReaderSceneActive = false
+                applyActivePlayback()
+                #endif
                 Task { @MainActor in
                     mediaOverlayManager?.isInBackground = true
                     let wasPlaying =
@@ -881,7 +911,7 @@ class EbookPlayerViewModel {
                         debugLog(
                             "[EbookPlayerViewModel] Book has media overlay - MediaOverlayManager created (native structure: \(useNativeStructure))"
                         )
-                        manager.setPlaybackRate(self.settingsVM.defaultPlaybackSpeed)
+                        manager.setPlaybackRate(self.activePlaybackRate)
                         self.mediaOverlayManager = manager
                         self.hasAudioNarration = true
                         self.styleManager?.setReadaloudModeAvailable(true)

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/MediaOverlayManager.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/MediaOverlayManager.swift
@@ -242,7 +242,6 @@ class MediaOverlayManager {
                 entryIndex: state.currentEntryIndex,
             )
         }
-
         if wasPlaying && !state.isPlaying {
             debugLog("[MOM] Audio paused - syncing progress")
             Task {
@@ -680,6 +679,7 @@ class MediaOverlayManager {
     }
 
     func setPlaybackRate(_ rate: Double) {
+        guard playbackRate != rate else { return }
         playbackRate = rate
         debugLog("[MOM] Playback rate set to: \(rate)x")
         Task {

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/PlaybackRateButton.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/PlaybackRateButton.swift
@@ -2,8 +2,7 @@
 import SwiftUI
 
 public struct PlaybackRateButton: View {
-    private let currentRate: Double
-    private let onRateChange: (Double) -> Void
+    private let playbackSpeeds: PlaybackSpeedControls
     private let backgroundColor: Color
     private let foregroundColor: Color
     private let transparency: Double
@@ -13,14 +12,18 @@ public struct PlaybackRateButton: View {
     private let compactLabel: Bool
     private let iconFont: Font
 
+    @ScaledMetric(relativeTo: .caption) private var presetButtonWidth: CGFloat = 60
+
     @State private var showSpeedPicker = false
-    @State private var sliderValue: Double = 1.0
-    @State private var textFieldValue: String = ""
-    @FocusState private var isTextFieldFocused: Bool
+    #if os(iOS)
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @State private var selectedSpeedSheetDetent: PresentationDetent = .custom(
+        CompactPlaybackSpeedDetent.self
+    )
+    #endif
 
     public init(
-        currentRate: Double,
-        onRateChange: @escaping (Double) -> Void,
+        playbackSpeeds: PlaybackSpeedControls,
         backgroundColor: Color = Color.secondary,
         foregroundColor: Color = Color.primary,
         transparency: Double = 1.0,
@@ -30,8 +33,7 @@ public struct PlaybackRateButton: View {
         compactLabel: Bool = false,
         iconFont: Font = .callout.weight(.semibold),
     ) {
-        self.currentRate = currentRate
-        self.onRateChange = onRateChange
+        self.playbackSpeeds = playbackSpeeds
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
         self.transparency = transparency
@@ -40,63 +42,54 @@ public struct PlaybackRateButton: View {
         self.showBackground = showBackground
         self.compactLabel = compactLabel
         self.iconFont = iconFont
+        #if os(iOS)
+        if !playbackSpeeds.isDual {
+            _selectedSpeedSheetDetent = State(
+                initialValue: .custom(CompactSinglePlaybackSpeedDetent.self)
+            )
+        }
+        #endif
+    }
+
+    public init(
+        currentRate: Double,
+        rate: Binding<Double>,
+        backgroundColor: Color = Color.secondary,
+        foregroundColor: Color = Color.primary,
+        transparency: Double = 1.0,
+        showLabel: Bool = true,
+        buttonSize: CGFloat = 38,
+        showBackground: Bool = true,
+        compactLabel: Bool = false,
+        iconFont: Font = .callout.weight(.semibold),
+    ) {
+        self.init(
+            playbackSpeeds: .single(currentRate: currentRate, rate: rate),
+            backgroundColor: backgroundColor,
+            foregroundColor: foregroundColor,
+            transparency: transparency,
+            showLabel: showLabel,
+            buttonSize: buttonSize,
+            showBackground: showBackground,
+            compactLabel: compactLabel,
+            iconFont: iconFont,
+        )
     }
 
     public var body: some View {
         VStack(spacing: compactLabel ? 0 : 6) {
             #if os(iOS)
-            Button(action: {
-                sliderValue = currentRate
-                textFieldValue = formatRate(currentRate)
-                showSpeedPicker = true
-            }) {
-                Image(systemName: "speedometer")
-                    .font(iconFont)
-                    .foregroundStyle(foregroundColor.opacity(transparency))
-                    .frame(width: buttonSize, height: buttonSize)
-                    .background(
-                        Group {
-                            if showBackground {
-                                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .fill(backgroundColor.opacity(0.12 * transparency))
-                            }
-                        }
-                    )
-            }
-            .buttonStyle(.plain)
-            .sheet(isPresented: $showSpeedPicker) {
-                speedSheet
-            }
-            #else
-            Button(action: {
-                sliderValue = currentRate
-                textFieldValue = formatRate(currentRate)
-                showSpeedPicker = true
-            }) {
-                Image(systemName: "speedometer")
-                    .font(iconFont)
-                    .foregroundStyle(foregroundColor.opacity(transparency))
-                    .frame(width: buttonSize, height: buttonSize)
-                    .background(
-                        Group {
-                            if showBackground {
-                                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .fill(backgroundColor.opacity(0.12 * transparency))
-                            }
-                        }
-                    )
-            }
-            .buttonStyle(.plain)
-            .popover(isPresented: $showSpeedPicker) {
-                speedPickerContent
-                    .frame(width: 340)
-                    .padding()
-            }
-            .onChange(of: showSpeedPicker) { _, isShowing in
-                if !isShowing {
-                    applyTextFieldValue()
+            speedPickerButton
+                .sheet(isPresented: $showSpeedPicker) {
+                    speedSheet
                 }
-            }
+            #else
+            speedPickerButton
+                .popover(isPresented: $showSpeedPicker) {
+                    speedPickerContent
+                        .frame(width: playbackSpeeds.isDual ? 440 : 340)
+                        .padding()
+                }
             #endif
 
             if showLabel && !compactLabel {
@@ -115,135 +108,177 @@ public struct PlaybackRateButton: View {
         }
     }
 
+    private var speedPickerButton: some View {
+        Button(action: presentSpeedPicker) {
+            Image(systemName: "speedometer")
+                .font(iconFont)
+                .foregroundStyle(foregroundColor.opacity(transparency))
+                .frame(width: buttonSize, height: buttonSize)
+                .background {
+                    if showBackground {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(backgroundColor.opacity(0.12 * transparency))
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(speedPickerTitle)
+    }
+
     private var speedPickerContent: some View {
-        HStack(spacing: 12) {
-            Text("1x")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Slider(
-                value: $sliderValue,
-                in: 1.0...3.0,
-                step: 0.05,
-            )
-            .onChange(of: sliderValue) { _, newValue in
-                let snapped = snapToIncrement(newValue)
-                textFieldValue = formatRate(snapped)
-                onRateChange(snapped)
-            }
-
-            Text("3x")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 4) {
-                TextField("1.0", text: $textFieldValue)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 60)
-                    .multilineTextAlignment(.center)
-                    #if os(iOS)
-                .keyboardType(.decimalPad)
-                    #endif
-                    .focused($isTextFieldFocused)
-                    .onSubmit {
-                        applyTextFieldValue()
-                    }
-                    .onChange(of: isTextFieldFocused) { _, focused in
-                        if !focused {
-                            applyTextFieldValue()
-                        }
-                    }
-
-                Text("x")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 24) {
+            switch playbackSpeeds {
+                case .single(_, let rate):
+                    speedControl(title: "Playback Speed", value: rate)
+                case .dual(_, let listeningRate, let readaloudRate):
+                    speedControl(title: "Listening Speed", value: listeningRate)
+                    speedControl(title: "Read-aloud Speed", value: readaloudRate)
             }
         }
+    }
+
+    private var presetGridColumns: [GridItem] {
+        [
+            GridItem(
+                .adaptive(
+                    minimum: presetButtonWidth,
+                    maximum: presetButtonWidth,
+                ),
+                spacing: 8,
+            )
+        ]
+    }
+
+    private func speedControl(title: String, value: Binding<Double>) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text(PlaybackRatePolicy.formattedCurrentRate(value.wrappedValue))
+                    .font(.subheadline.monospacedDigit().weight(.semibold))
+            }
+
+            Slider(
+                value: value,
+                in: PlaybackRatePolicy.minimumRate...PlaybackRatePolicy.maximumRate,
+                step: PlaybackRatePolicy.sliderStep,
+            )
+
+            LazyVGrid(
+                columns: presetGridColumns,
+                alignment: .leading,
+                spacing: 8,
+            ) {
+                ForEach(PlaybackRatePolicy.presetRates, id: \.self) { rate in
+                    Button {
+                        value.wrappedValue = rate
+                    } label: {
+                        Text(PlaybackRatePolicy.formattedPresetRate(rate))
+                            .font(.caption.monospacedDigit().weight(.medium))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                            .foregroundStyle(Color.primary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 6)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .fill(Color.secondary.opacity(0.1))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .frame(maxWidth: 400, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     #if os(iOS)
     private var speedSheet: some View {
-        NavigationStack {
-            VStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(speedPickerTitle)
+                    .font(.title2.weight(.bold))
+
                 Spacer()
-                speedPickerContent
-                    .padding(.horizontal, 16)
 
-                HStack(spacing: 24) {
-                    Button(action: {
-                        let newRate = max(0.5, sliderValue - 0.05)
-                        sliderValue = snapToIncrement(newRate)
-                        textFieldValue = formatRate(sliderValue)
-                        onRateChange(sliderValue)
-                    }) {
-                        Image(systemName: "minus.circle.fill")
-                            .font(.title)
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-
-                    Button(action: {
-                        let newRate = min(10.0, sliderValue + 0.05)
-                        sliderValue = snapToIncrement(newRate)
-                        textFieldValue = formatRate(sliderValue)
-                        onRateChange(sliderValue)
-                    }) {
-                        Image(systemName: "plus.circle.fill")
-                            .font(.title)
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
+                Button("Done") {
+                    showSpeedPicker = false
                 }
-
-                Spacer()
+                .font(.body.weight(.semibold))
             }
-            .navigationTitle("Playback Speed")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        applyTextFieldValue()
-                        showSpeedPicker = false
-                    }
+
+            ViewThatFits(in: .vertical) {
+                speedPickerContent
+                    .fixedSize(horizontal: false, vertical: true)
+
+                ScrollView {
+                    speedPickerContent
+                        .padding(.bottom, 4)
                 }
+                .scrollIndicators(.visible)
             }
         }
-        .presentationDetents([.height(180)])
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
+        .padding(.bottom, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .presentationDetents(
+            speedSheetDetents,
+            selection: $selectedSpeedSheetDetent,
+        )
+        .presentationDragIndicator(.visible)
+        .onChange(of: dynamicTypeSize) { _, newSize in
+            selectedSpeedSheetDetent = preferredSpeedSheetDetent(for: newSize)
+        }
     }
     #endif
 
-    private func snapToIncrement(_ value: Double) -> Double {
-        (value * 20).rounded() / 20
+    private func presentSpeedPicker() {
+        #if os(iOS)
+        selectedSpeedSheetDetent = preferredSpeedSheetDetent(for: dynamicTypeSize)
+        #endif
+        showSpeedPicker = true
     }
 
-    private func formatRate(_ rate: Double) -> String {
-        if rate == rate.rounded() {
-            return String(format: "%.1f", rate)
+    #if os(iOS)
+    private func preferredSpeedSheetDetent(for typeSize: DynamicTypeSize) -> PresentationDetent {
+        if typeSize > .large {
+            return .large
         }
-        let formatted = String(format: "%.2f", rate)
-        if formatted.hasSuffix("0") {
-            return String(format: "%.1f", rate)
-        }
-        return formatted
+        return playbackSpeeds.isDual
+            ? .custom(CompactPlaybackSpeedDetent.self)
+            : .custom(CompactSinglePlaybackSpeedDetent.self)
     }
 
-    private func applyTextFieldValue() {
-        if let rate = Double(textFieldValue) {
-            let clampedRate = min(max(rate, 0.5), 10.0)
-            textFieldValue = formatRate(clampedRate)
-            onRateChange(clampedRate)
-        } else {
-            textFieldValue = formatRate(sliderValue)
-        }
+    private var speedSheetDetents: Set<PresentationDetent> {
+        [preferredSpeedSheetDetent(for: .large), .large]
+    }
+    #endif
+
+    private var speedPickerTitle: String {
+        playbackSpeeds.isDual ? "Playback Speeds" : "Playback Speed"
     }
 
     private var playbackRateDescription: String {
-        let formatted = String(format: "%.2fx", currentRate)
-        if formatted.hasSuffix("0x") {
-            return String(format: "%.1fx", currentRate)
-        }
-        return formatted
+        PlaybackRatePolicy.formattedCurrentRate(playbackSpeeds.currentRate)
     }
 }
+
+#if os(iOS)
+private struct CompactPlaybackSpeedDetent: CustomPresentationDetent {
+    static func height(in context: Context) -> CGFloat? {
+        min(context.maxDetentValue * 0.7, 500)
+    }
+}
+
+private struct CompactSinglePlaybackSpeedDetent: CustomPresentationDetent {
+    static func height(in context: Context) -> CGFloat? {
+        min(context.maxDetentValue * 0.55, 360)
+    }
+}
+#endif
 
 #endif

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/ReadingSidebarView.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/ReadingSidebarView.swift
@@ -20,7 +20,6 @@ public struct ReadingSidebarView: View {
         public var ebookCoverArt: Image?
         public var chapterDuration: TimeInterval
         public var totalRemaining: TimeInterval
-        public var playbackRate: Double
         public var volume: Double
         public var isPlaying: Bool
         public var sleepTimerActive: Bool
@@ -35,7 +34,6 @@ public struct ReadingSidebarView: View {
             ebookCoverArt: Image? = nil,
             chapterDuration: TimeInterval,
             totalRemaining: TimeInterval,
-            playbackRate: Double,
             volume: Double = 1.0,
             isPlaying: Bool,
             sleepTimerActive: Bool = false,
@@ -49,7 +47,6 @@ public struct ReadingSidebarView: View {
             self.ebookCoverArt = ebookCoverArt
             self.chapterDuration = chapterDuration
             self.totalRemaining = totalRemaining
-            self.playbackRate = playbackRate
             self.volume = volume
             self.isPlaying = isPlaying
             self.sleepTimerActive = sleepTimerActive
@@ -68,6 +65,7 @@ public struct ReadingSidebarView: View {
     private let onChapterSelected: (ChapterItem) -> Void
     private let onProgressSeek: ((Double) -> Void)?
     private let seekWhileDragging: Bool
+    private let playbackSpeeds: PlaybackSpeedControls
 
     @State private var showVolumePopover = false
     @State private var showSleepTimerPopover = false
@@ -82,7 +80,6 @@ public struct ReadingSidebarView: View {
     private let onPlayPause: () -> Void
     private let onSkipForward: () -> Void
     private let onNextChapter: () -> Void
-    private let onPlaybackRateChange: (Double) -> Void
     private let onVolumeChange: (Double) -> Void
     private let onSleepTimerStart: (TimeInterval?, SleepTimerType) -> Void
     private let onSleepTimerCancel: () -> Void
@@ -101,7 +98,7 @@ public struct ReadingSidebarView: View {
         onPlayPause: @escaping () -> Void = {},
         onSkipForward: @escaping () -> Void = {},
         onNextChapter: @escaping () -> Void = {},
-        onPlaybackRateChange: @escaping (Double) -> Void = { _ in },
+        playbackSpeeds: PlaybackSpeedControls,
         onVolumeChange: @escaping (Double) -> Void = { _ in },
         onSleepTimerStart: @escaping (TimeInterval?, SleepTimerType) -> Void = { _, _ in },
         onSleepTimerCancel: @escaping () -> Void = {},
@@ -121,7 +118,7 @@ public struct ReadingSidebarView: View {
         self.onPlayPause = onPlayPause
         self.onSkipForward = onSkipForward
         self.onNextChapter = onNextChapter
-        self.onPlaybackRateChange = onPlaybackRateChange
+        self.playbackSpeeds = playbackSpeeds
         self.onVolumeChange = onVolumeChange
         self.onSleepTimerStart = onSleepTimerStart
         self.onSleepTimerCancel = onSleepTimerCancel
@@ -288,12 +285,12 @@ public struct ReadingSidebarView: View {
             normalizedSeconds(progressData?.chapterTotalSecondsAudio) ?? model.chapterDuration
         let chapterTotalRaw = max(baseChapterTotalRaw, chapterElapsedRaw)
 
-        let rate = max(model.playbackRate, 0.01)
+        let rate = max(playbackSpeeds.currentRate, 0.01)
         let chapterElapsed = chapterElapsedRaw / rate
         let chapterTotal = chapterTotalRaw / rate
         let rawRemaining = max(chapterTotal - chapterElapsed, 0)
         let chapterRemainingAtRate = timeRemaining(
-            atRate: model.playbackRate,
+            atRate: playbackSpeeds.currentRate,
             total: chapterTotalRaw,
             elapsed: chapterElapsedRaw,
         )
@@ -406,14 +403,7 @@ public struct ReadingSidebarView: View {
     private var secondaryControls: some View {
         HStack(spacing: 32) {
             if mode != .ebook {
-                PlaybackRateButton(
-                    currentRate: model.playbackRate,
-                    onRateChange: onPlaybackRateChange,
-                    backgroundColor: secondaryColor,
-                    foregroundColor: primaryColor,
-                    transparency: 1.0,
-                    showLabel: true,
-                )
+                playbackRateButton
             }
 
             ChaptersButton(
@@ -460,6 +450,16 @@ public struct ReadingSidebarView: View {
         .padding(.horizontal, 20)
     }
 
+    private var playbackRateButton: some View {
+        PlaybackRateButton(
+            playbackSpeeds: playbackSpeeds,
+            backgroundColor: secondaryColor,
+            foregroundColor: primaryColor,
+            transparency: 1.0,
+            showLabel: true,
+        )
+    }
+
     @ViewBuilder
     private var statsSection: some View {
         let data = progressData
@@ -478,12 +478,12 @@ public struct ReadingSidebarView: View {
         let chapterTotalRaw = data.flatMap { normalizedSeconds($0.chapterTotalSecondsAudio) }
 
         let bookRemaining = timeRemaining(
-            atRate: model.playbackRate,
+            atRate: playbackSpeeds.currentRate,
             total: bookTotalRaw,
             elapsed: bookElapsedRaw,
         )
         let chapterRemaining = timeRemaining(
-            atRate: model.playbackRate,
+            atRate: playbackSpeeds.currentRate,
             total: chapterTotalRaw,
             elapsed: chapterElapsedRaw,
         )
@@ -723,7 +723,7 @@ public struct ReadingSidebarView: View {
     }
 
     private var playbackRateDescription: String {
-        SilveranAppleKit.playbackRateDescription(for: model.playbackRate)
+        SilveranAppleKit.playbackRateDescription(for: playbackSpeeds.currentRate)
     }
 
     private var elapsedTime: TimeInterval {
@@ -740,7 +740,6 @@ public struct ReadingSidebarView: View {
         coverArt: nil,
         chapterDuration: (12 * 60) + 27,
         totalRemaining: (8 * 60 * 60) + (9 * 60),
-        playbackRate: 1.3,
         isPlaying: true,
     )
     let progress = ProgressData(
@@ -759,6 +758,11 @@ public struct ReadingSidebarView: View {
         mode: .readaloud,
         chapterProgress: .constant(Double((4 * 60) + 7) / Double((12 * 60) + 27)),
         progressData: progress,
+        playbackSpeeds: .dual(
+            currentRate: 1.3,
+            listeningRate: .constant(1.0),
+            readaloudRate: .constant(1.3),
+        ),
     )
     .frame(maxWidth: 420)
 }

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/SettingsView.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/SettingsView.swift
@@ -180,7 +180,7 @@ public struct SettingsView: View {
                     enableMarginClickNavigation: newValue.reading.enableMarginClickNavigation,
                     singleColumnMode: newValue.reading.singleColumnMode,
                     scrollingMode: newValue.reading.scrollingMode,
-                    defaultPlaybackSpeed: newValue.playback.defaultPlaybackSpeed,
+                    playback: newValue.playback,
                     enableReadingBar: newValue.readingBar.enabled,
                     showPlayerControls: newValue.readingBar.showPlayerControls,
                     showProgressBar: newValue.readingBar.showProgressBar,
@@ -323,7 +323,8 @@ extension SettingsView {
         config.reading.singleColumnMode = false
         config.reading.scrollingMode = kDefaultScrollingMode
         config.reading.customCSS = nil
-        config.playback.defaultPlaybackSpeed = kDefaultPlaybackSpeed
+        config.playback.updatePlaybackSpeed(kDefaultPlaybackSpeed, for: .listening)
+        config.playback.updatePlaybackSpeed(kDefaultPlaybackSpeed, for: .readaloud)
     }
 }
 #else
@@ -639,6 +640,21 @@ private struct MacReaderSettingsView: View {
         ["System Default", "serif", "sans-serif", "monospace"]
     }
 
+    private var listeningSpeedBinding: Binding<Double> {
+        playbackSpeedBinding(for: .listening)
+    }
+
+    private var readaloudSpeedBinding: Binding<Double> {
+        playbackSpeedBinding(for: .readaloud)
+    }
+
+    private func playbackSpeedBinding(for role: PlaybackSpeedRole) -> Binding<Double> {
+        Binding(
+            get: { playback.playbackSpeed(for: role) },
+            set: { playback.updatePlaybackSpeed($0, for: role) },
+        )
+    }
+
     var body: some View {
         MacSettingsContainer(tab: .readerSettings) {
             Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 18) {
@@ -774,10 +790,20 @@ private struct MacReaderSettingsView: View {
                 }
 
                 GridRow {
-                    label("Playback Speed")
+                    label("Listening Speed")
                     MacSliderControl(
-                        value: $playback.defaultPlaybackSpeed,
-                        range: 0.5...3.0,
+                        value: listeningSpeedBinding,
+                        range: 0.75...4.0,
+                        step: 0.05,
+                        formatter: { String(format: "%.2fx", $0) },
+                    )
+                }
+
+                GridRow {
+                    label("Read-aloud Speed")
+                    MacSliderControl(
+                        value: readaloudSpeedBinding,
+                        range: 0.75...4.0,
                         step: 0.05,
                         formatter: { String(format: "%.2fx", $0) },
                     )

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/iOSApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/iOSApp/CarPlay/CarPlaySceneDelegate.swift
@@ -157,9 +157,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     private func showSpeedList() {
         Task { @MainActor in
-            let speeds: [Double] = [
-                0.75, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 5.0,
-            ]
+            let speeds = PlaybackSpeedPolicy.quickPresetRates
             let currentRate = CarPlayCoordinator.shared.currentPlaybackRate
 
             let items: [CPListItem] = speeds.map { speed in

--- a/SilveranKit/Sources/AppleKit/tvOS/Views/TVSpeedPickerView.swift
+++ b/SilveranKit/Sources/AppleKit/tvOS/Views/TVSpeedPickerView.swift
@@ -7,9 +7,7 @@ struct TVSpeedPickerView: View {
     @Environment(\.dismiss) private var dismiss
     @FocusState private var focusedIndex: Int?
 
-    private let speeds: [Double] = [
-        0.75, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 5.0,
-    ]
+    private let speeds = PlaybackSpeedPolicy.quickPresetRates
 
     private var currentSpeedIndex: Int? {
         speeds.firstIndex { abs($0 - viewModel.playbackRate) < 0.01 }

--- a/SilveranKit/Sources/AppleKit/watchOS/WatchPlayerView.swift
+++ b/SilveranKit/Sources/AppleKit/watchOS/WatchPlayerView.swift
@@ -377,9 +377,7 @@ private struct SpeedPickerSheet: View {
     let currentRate: Double
     let onSelect: (Double) -> Void
 
-    private let speeds: [Double] = [
-        0.75, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 5.0,
-    ]
+    private let speeds = PlaybackSpeedPolicy.quickPresetRates
 
     private var currentSpeedIndex: Int {
         speeds.firstIndex { abs($0 - currentRate) < 0.01 } ?? 1

--- a/SilveranKit/Sources/Kit/Actors/SMILPlayerActor.swift
+++ b/SilveranKit/Sources/Kit/Actors/SMILPlayerActor.swift
@@ -383,8 +383,10 @@ public actor SMILPlayerActor {
     }
 
     public func setPlaybackRate(_ rate: Double) async {
+        let rateChanged = playbackRate != rate
         playbackRate = rate
         await player?.setRate(rate)
+        guard rateChanged else { return }
         debugLog("[SMILPlayerActor] Playback rate set to \(rate)")
         await notifyStateChange()
     }

--- a/SilveranKit/Sources/Kit/Actors/SettingsActor.swift
+++ b/SilveranKit/Sources/Kit/Actors/SettingsActor.swift
@@ -380,22 +380,63 @@ public struct SilveranGlobalConfig: Codable, Equatable, Sendable {
     }
 
     public struct Playback: Codable, Equatable, Sendable {
-        public var defaultPlaybackSpeed: Double
+        public private(set) var defaultPlaybackSpeed: Double
+        public private(set) var readaloudPlaybackSpeed: Double
         public var defaultVolume: Double
         public var statsExpanded: Bool
         public var lockViewToAudio: Bool
 
         public init(
             defaultPlaybackSpeed: Double = kDefaultPlaybackSpeed,
+            readaloudPlaybackSpeed: Double? = nil,
             defaultVolume: Double = kDefaultVolume,
             statsExpanded: Bool = kDefaultStatsExpanded,
             lockViewToAudio: Bool = kDefaultLockViewToAudio,
         ) {
-            self.defaultPlaybackSpeed = defaultPlaybackSpeed
+            let normalizedDefaultSpeed = Self.normalizedSpeed(defaultPlaybackSpeed)
+            let normalizedReadaloudSpeed = Self.normalizedSpeed(
+                readaloudPlaybackSpeed ?? defaultPlaybackSpeed
+            )
+            self.defaultPlaybackSpeed = min(normalizedDefaultSpeed, normalizedReadaloudSpeed)
+            self.readaloudPlaybackSpeed = normalizedReadaloudSpeed
             self.defaultVolume = defaultVolume
             self.statsExpanded = statsExpanded
             self.lockViewToAudio = lockViewToAudio
         }
+
+        public mutating func updateDefaultPlaybackSpeed(_ speed: Double) {
+            updatePlaybackSpeed(speed, for: .listening)
+        }
+
+        public mutating func updateReadaloudPlaybackSpeed(_ speed: Double) {
+            updatePlaybackSpeed(speed, for: .readaloud)
+        }
+
+        public mutating func updatePlaybackSpeed(_ speed: Double, for role: PlaybackSpeedRole) {
+            switch role {
+                case .listening:
+                    defaultPlaybackSpeed = Self.normalizedSpeed(speed)
+                    readaloudPlaybackSpeed = max(readaloudPlaybackSpeed, defaultPlaybackSpeed)
+                case .readaloud:
+                    readaloudPlaybackSpeed = Self.normalizedSpeed(speed)
+                    defaultPlaybackSpeed = min(defaultPlaybackSpeed, readaloudPlaybackSpeed)
+            }
+        }
+
+        public func playbackSpeed(for role: PlaybackSpeedRole) -> Double {
+            switch role {
+                case .listening:
+                    defaultPlaybackSpeed
+                case .readaloud:
+                    readaloudPlaybackSpeed
+            }
+        }
+
+        private static func normalizedSpeed(_ speed: Double) -> Double {
+            guard speed.isFinite else { return kDefaultPlaybackSpeed }
+            return min(max(speed, kMinimumPlaybackSpeed), kMaximumPlaybackSpeed)
+        }
+
     }
 
     public struct ReadingBar: Codable, Equatable, Sendable {
@@ -742,7 +783,9 @@ public actor SettingsActor {
         enableMarginClickNavigation: Bool? = nil,
         singleColumnMode: Bool? = nil,
         scrollingMode: Bool? = nil,
+        playback: SilveranGlobalConfig.Playback? = nil,
         defaultPlaybackSpeed: Double? = nil,
+        readaloudPlaybackSpeed: Double? = nil,
         defaultVolume: Double? = nil,
         statsExpanded: Bool? = nil,
         lockViewToAudio: Bool? = nil,
@@ -815,7 +858,15 @@ public actor SettingsActor {
         if let scrollingMode {
             updated.reading.scrollingMode = scrollingMode
         }
-        if let defaultPlaybackSpeed { updated.playback.defaultPlaybackSpeed = defaultPlaybackSpeed }
+        if let playback {
+            updated.playback = playback
+        }
+        if let defaultPlaybackSpeed {
+            updated.playback.updateDefaultPlaybackSpeed(defaultPlaybackSpeed)
+        }
+        if let readaloudPlaybackSpeed {
+            updated.playback.updateReadaloudPlaybackSpeed(readaloudPlaybackSpeed)
+        }
         if let defaultVolume { updated.playback.defaultVolume = defaultVolume }
         if let statsExpanded { updated.playback.statsExpanded = statsExpanded }
         if let lockViewToAudio { updated.playback.lockViewToAudio = lockViewToAudio }

--- a/SilveranKit/Sources/Kit/SettingsDefaults.swift
+++ b/SilveranKit/Sources/Kit/SettingsDefaults.swift
@@ -51,9 +51,31 @@ public let kDefaultReadaloudHighlightMode = "background"
 // MARK: - Playback Settings
 
 public let kDefaultPlaybackSpeed: Double = 1.0
+public let kMinimumPlaybackSpeed: Double = 0.75
+public let kMaximumPlaybackSpeed: Double = 4.0
 public let kDefaultVolume: Double = 1.0
 public let kDefaultStatsExpanded = false
 public let kDefaultLockViewToAudio = true
+
+public enum PlaybackSpeedRole: Equatable, Sendable {
+    case listening
+    case readaloud
+}
+
+public enum PlaybackSpeedPolicy {
+    public static let sliderStep = 0.05
+    public static let presetStep = 0.25
+
+    public static let presetRates = stride(
+        from: kMinimumPlaybackSpeed,
+        through: kMaximumPlaybackSpeed,
+        by: presetStep,
+    ).map { $0 }
+
+    public static let quickPresetRates = [
+        0.75, 1.0, 1.1, 1.2, 1.3, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 4.0,
+    ]
+}
 
 // MARK: - Reading Bar Settings
 

--- a/SilveranKit/Tests/SilveranTests/PlaybackSettingsTests.swift
+++ b/SilveranKit/Tests/SilveranTests/PlaybackSettingsTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+@testable import SilveranAppleKit
+@testable import SilveranKit
+
+@Test func playbackSpeedsRoundTripIndependently() throws {
+    let original = SilveranGlobalConfig(
+        playback: .init(
+            defaultPlaybackSpeed: 1.25,
+            readaloudPlaybackSpeed: 2.5,
+        )
+    )
+
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(SilveranGlobalConfig.self, from: encoded)
+
+    #expect(decoded.playback.defaultPlaybackSpeed == 1.25)
+    #expect(decoded.playback.readaloudPlaybackSpeed == 2.5)
+}
+
+@Test func playbackSpeedUpdatesPreserveTheSupportedRangeAndCoupling() {
+    var playback = SilveranGlobalConfig.Playback(
+        defaultPlaybackSpeed: 5.0,
+        readaloudPlaybackSpeed: 10.0,
+    )
+
+    #expect(playback.defaultPlaybackSpeed == kMaximumPlaybackSpeed)
+    #expect(playback.readaloudPlaybackSpeed == kMaximumPlaybackSpeed)
+
+    playback.updateReadaloudPlaybackSpeed(0.5)
+    #expect(playback.defaultPlaybackSpeed == kMinimumPlaybackSpeed)
+    #expect(playback.readaloudPlaybackSpeed == kMinimumPlaybackSpeed)
+
+    playback.updateDefaultPlaybackSpeed(5.0)
+    #expect(playback.defaultPlaybackSpeed == kMaximumPlaybackSpeed)
+    #expect(playback.readaloudPlaybackSpeed == kMaximumPlaybackSpeed)
+}
+
+@Test func orderedPlaybackSpeedUpdatesApplyToTheLatestState() {
+    var playback = SilveranGlobalConfig.Playback(
+        defaultPlaybackSpeed: 1.0,
+        readaloudPlaybackSpeed: 2.0,
+    )
+
+    playback.updatePlaybackSpeed(2.5, for: .listening)
+    playback.updatePlaybackSpeed(2.25, for: .readaloud)
+
+    #expect(playback.defaultPlaybackSpeed == 2.25)
+    #expect(playback.readaloudPlaybackSpeed == 2.25)
+}
+
+@Test func playbackSpeedPresetsCoverRequestedRangeInQuarterSteps() {
+    #expect(PlaybackSpeedPolicy.sliderStep == 0.05)
+    #expect(PlaybackSpeedPolicy.presetStep == 0.25)
+    #expect(PlaybackSpeedPolicy.presetRates.first == 0.75)
+    #expect(PlaybackSpeedPolicy.presetRates.last == 4.0)
+    #expect(PlaybackSpeedPolicy.presetRates.count == 14)
+    #expect(PlaybackRatePolicy.presetRates == PlaybackSpeedPolicy.presetRates)
+    #expect(
+        zip(
+            PlaybackSpeedPolicy.presetRates.dropFirst(),
+            PlaybackSpeedPolicy.presetRates,
+        ).allSatisfy { next, previous in
+            abs(next - previous - 0.25) < 0.001
+        }
+    )
+}
+
+@Test func currentPlaybackRateAlwaysUsesTwoDecimalPlaces() {
+    #expect(PlaybackRatePolicy.formattedCurrentRate(2.0) == "2.00x")
+    #expect(PlaybackRatePolicy.formattedCurrentRate(2.05) == "2.05x")
+    #expect(PlaybackRatePolicy.formattedPresetRate(2.0) == "2.0x")
+}
+
+@Test func compactPlatformSpeedPresetsShareTheSupportedRange() {
+    #expect(PlaybackSpeedPolicy.quickPresetRates.first == kMinimumPlaybackSpeed)
+    #expect(PlaybackSpeedPolicy.quickPresetRates.last == kMaximumPlaybackSpeed)
+    #expect(
+        PlaybackSpeedPolicy.quickPresetRates.allSatisfy { rate in
+            (kMinimumPlaybackSpeed...kMaximumPlaybackSpeed).contains(rate)
+        }
+    )
+}
+
+@Test(
+    arguments: [
+        (isReaderActive: true, isExpanded: false, expected: PlaybackSpeedRole.readaloud),
+        (isReaderActive: true, isExpanded: true, expected: PlaybackSpeedRole.listening),
+        (isReaderActive: false, isExpanded: false, expected: PlaybackSpeedRole.listening),
+        (isReaderActive: false, isExpanded: true, expected: PlaybackSpeedRole.listening),
+    ]
+)
+func playbackRoleSelectionUsesReadaloudOnlyInUnexpandedActiveReader(
+    context: (isReaderActive: Bool, isExpanded: Bool, expected: PlaybackSpeedRole)
+) {
+    let role = PlaybackRatePolicy.activeRole(
+        isReaderSceneActive: context.isReaderActive,
+        isPlayerExpanded: context.isExpanded,
+    )
+
+    #expect(role == context.expected)
+}
+
+@Test(
+    arguments: [
+        (listening: 2.0, readaloud: 1.5, expected: 2.0),
+        (listening: 1.5, readaloud: 2.0, expected: 2.0),
+        (listening: 2.0, readaloud: 2.0, expected: 2.0),
+    ]
+)
+func raisingListeningSpeedOnlyRaisesLowerReadaloudSpeed(
+    rates: (listening: Double, readaloud: Double, expected: Double)
+) {
+    var playback = SilveranGlobalConfig.Playback(
+        defaultPlaybackSpeed: 1.0,
+        readaloudPlaybackSpeed: rates.readaloud,
+    )
+    playback.updateDefaultPlaybackSpeed(rates.listening)
+
+    #expect(playback.defaultPlaybackSpeed == rates.listening)
+    #expect(playback.readaloudPlaybackSpeed == rates.expected)
+}
+
+@Test(
+    arguments: [
+        (listening: 2.0, readaloud: 1.5, expected: 1.5),
+        (listening: 1.5, readaloud: 2.0, expected: 1.5),
+        (listening: 2.0, readaloud: 2.0, expected: 2.0),
+    ]
+)
+func loweringReadaloudSpeedOnlyLowersHigherListeningSpeed(
+    rates: (listening: Double, readaloud: Double, expected: Double)
+) {
+    var playback = SilveranGlobalConfig.Playback(
+        defaultPlaybackSpeed: rates.listening,
+        readaloudPlaybackSpeed: 2.5,
+    )
+    playback.updateReadaloudPlaybackSpeed(rates.readaloud)
+
+    #expect(playback.defaultPlaybackSpeed == rates.expected)
+    #expect(playback.readaloudPlaybackSpeed == rates.readaloud)
+}


### PR DESCRIPTION
I still need to self review this and try to understand wtf is going on.

I produced this through a couple hours of going back and forth with codex, manually testing on iPhone 17 Pro simulator and iPhone SE (3rd generation) simulator to see how it does on small screens.

I tested with DynamicType turned way up to make sure that it's accessible.

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5b96a5c6-c166-4027-b724-f53ef14f1549" />

https://github.com/user-attachments/assets/ebbae1d7-5315-4ce2-8f6b-cde6f800db95

