### PR TITLE
Improve reader UX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "SilveranKit/Sources/AppleKit/Resources/WebResources/foliate-js"]
 	path = SilveranKit/Sources/AppleKit/Resources/WebResources/foliate-js
-	url = https://github.com/kyonifer/foliate-js.git
+	url = https://github.com/trcoffman/foliate-js.git
 [submodule "SilveranKit/Sources/AppleKit/Resources/assets"]
 	path = SilveranKit/Sources/AppleKit/Resources/assets
 	url = https://github.com/kyonifer/s-r-assets.git

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/EbookPlayerViewModel.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/EbookPlayerViewModel.swift
@@ -962,6 +962,7 @@ class EbookPlayerViewModel {
                 await self.mediaOverlayManager?.handleSeekEvent(
                     sectionIndex: message.sectionIndex,
                     anchor: message.anchor,
+                    startPlayback: message.startPlayback ?? false,
                 )
             }
         }

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/MediaOverlayManager.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/MediaOverlayManager.swift
@@ -409,8 +409,14 @@ class MediaOverlayManager {
     /// - User double-clicks on a sentence in the reader
     /// - Book opens at last reading position (future)
     /// Only seeks if the exact fragment exists in bookStructure for the requested section
-    func handleSeekEvent(sectionIndex: Int, anchor: String) async {
-        debugLog("[MOM] handleSeekEvent - section: \(sectionIndex), anchor: \(anchor)")
+    func handleSeekEvent(
+        sectionIndex: Int,
+        anchor: String,
+        startPlayback: Bool = false
+    ) async {
+        debugLog(
+            "[MOM] handleSeekEvent - section: \(sectionIndex), anchor: \(anchor), startPlayback: \(startPlayback)"
+        )
 
         guard let section = getSection(at: sectionIndex) else {
             debugLog("[MOM] ERROR: handleSeekEvent - invalid section index: \(sectionIndex)")
@@ -439,7 +445,13 @@ class MediaOverlayManager {
         )
         if success {
             debugLog("[MOM] handleSeekEvent - seek successful")
-            await sendHighlightCommand(sectionIndex: sectionIndex, textId: anchor)
+
+            if startPlayback && !wasPlaying {
+                debugLog("[MOM] handleSeekEvent - starting playback")
+                await startPlaying()
+            } else {
+                await sendHighlightCommand(sectionIndex: sectionIndex, textId: anchor)
+            }
 
             if wasPlaying {
                 debugLog("[MOM] handleSeekEvent - resuming playback")

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/MediaOverlayManager.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/MediaOverlayManager.swift
@@ -222,6 +222,11 @@ class MediaOverlayManager {
 
         let wasPlaying = isPlaying
         isPlaying = state.isPlaying
+        if wasPlaying != isPlaying {
+            Task {
+                try? await commsBridge?.sendJsSetPlaybackActive(isPlaying)
+            }
+        }
         if isInBackground && state.isPlaying {
             backgroundAudioPlayed = true
         }
@@ -473,6 +478,7 @@ class MediaOverlayManager {
 
             try await SMILPlayerActor.shared.play()
             isPlaying = true
+            try? await commsBridge?.sendJsSetPlaybackActive(true)
 
             if let entry = await SMILPlayerActor.shared.getCurrentEntry() {
                 let (currentSectionIndex, _) = await SMILPlayerActor.shared.getCurrentPosition()
@@ -499,6 +505,7 @@ class MediaOverlayManager {
         disableScreenWakeLock()
         await SMILPlayerActor.shared.pause()
         isPlaying = false
+        try? await commsBridge?.sendJsSetPlaybackActive(false)
         pageFlipTimer?.invalidate()
         pageFlipTimer = nil
         debugLog("[MOM] stopPlaying() - paused")
@@ -793,6 +800,7 @@ class MediaOverlayManager {
             await SMILPlayerActor.shared.pause()
         }
 
+        try? await commsBridge?.sendJsSetPlaybackActive(false)
         try? await commsBridge?.sendJsClearHighlight()
         debugLog("[MOM] Cleanup completed")
     }
@@ -923,6 +931,8 @@ class MediaOverlayManager {
         pageFlipTimer = nil
 
         guard isPlaying else { return }
+        let sectionIndex = cachedSectionIndex
+        let textId = message.textId
 
         debugLog(
             "[MOM] Element visibility: textId=\(message.textId), visible=\(message.visibleRatio), offScreen=\(message.offScreenRatio)"
@@ -931,7 +941,7 @@ class MediaOverlayManager {
         if message.offScreenRatio >= 0.9 {
             debugLog("[MOM] Element almost fully off-screen, flipping immediately")
             Task {
-                await self.flipPageIfNotDebounced()
+                await self.flipPageIfNotDebounced(sectionIndex: sectionIndex, textId: textId)
             }
         } else if message.offScreenRatio > 0 {
             Task {
@@ -954,7 +964,10 @@ class MediaOverlayManager {
                     ) {
                         [weak self] _ in
                         Task { @MainActor [weak self] in
-                            await self?.flipPageIfNotDebounced()
+                            await self?.flipPageIfNotDebounced(
+                                sectionIndex: sectionIndex,
+                                textId: textId
+                            )
                         }
                     }
                 }
@@ -962,7 +975,7 @@ class MediaOverlayManager {
         }
     }
 
-    private func flipPageIfNotDebounced() async {
+    private func flipPageIfNotDebounced(sectionIndex: Int, textId: String) async {
         guard isPlaying else { return }
 
         if let last = lastFlipTime, Date().timeIntervalSince(last) < 0.3 {
@@ -971,8 +984,12 @@ class MediaOverlayManager {
         }
 
         lastFlipTime = Date()
-        debugLog("[MOM] Page flip")
-        try? await commsBridge?.sendJsGoRightCommand()
+        let didFlip =
+            (try? await commsBridge?.sendJsGoRightForAudioCommand(
+                sectionIndex: sectionIndex,
+                textId: textId
+            )) ?? false
+        debugLog(didFlip ? "[MOM] Page flip" : "[MOM] Page flip skipped or deferred")
     }
 }
 

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/WebViewCommsBridge.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/WebViewCommsBridge.swift
@@ -173,6 +173,29 @@ class WebViewCommsBridge {
         _ = try await webView.evaluateJavaScript("window.foliateManager.goRight()")
     }
 
+    /// Requests an audio-follow page flip. JS may defer it while the reader is being touched.
+    func sendJsGoRightForAudioCommand(sectionIndex: Int, textId: String) async throws -> Bool {
+        guard let webView = webView else {
+            throw WebViewCommsBridgeError.webViewNotAvailable
+        }
+
+        debugLog(
+            "[WebViewCommsBridge] sendJsGoRightForAudioCommand(sectionIndex: \(sectionIndex), textId: \(textId))"
+        )
+        let result = try await webView.callAsyncJavaScript(
+            """
+            return window.foliateManager.goRightForAudio(sectionIndex, textId);
+            """,
+            arguments: [
+                "sectionIndex": sectionIndex,
+                "textId": textId,
+            ],
+            in: nil,
+            contentWorld: .page,
+        )
+        return result as? Bool ?? false
+    }
+
     /// Swift commands JS to navigate to a specific href (with optional fragment)
     func sendJsGoToHrefCommand(href: String) async throws {
         guard let webView = webView else {
@@ -278,6 +301,18 @@ class WebViewCommsBridge {
     }
 
     // MARK: - Highlight controls (Swift controls audio directly)
+
+    /// Updates reader interaction policy for active audio playback.
+    func sendJsSetPlaybackActive(_ active: Bool) async throws {
+        guard let webView = webView else {
+            throw WebViewCommsBridgeError.webViewNotAvailable
+        }
+
+        debugLog("[WebViewCommsBridge] sendJsSetPlaybackActive(\(active))")
+        _ = try await webView.evaluateJavaScript(
+            "window.foliateManager.setPlaybackActive(\(active))"
+        )
+    }
 
     /// Swift commands JS to highlight a specific text fragment
     /// JS will apply highlight CSS and report visibility for page flip timing

--- a/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/WebViewMessages.swift
+++ b/SilveranKit/Sources/AppleKit/MobileDesktop/Views/Player/EbookPlayer/WebViewMessages.swift
@@ -52,6 +52,7 @@ struct SentenceSkipMessage: Codable {
 struct MediaOverlaySeekMessage: Codable {
     let sectionIndex: Int
     let anchor: String
+    let startPlayback: Bool?
 }
 
 // SectionInfo and SMILEntry are defined in Common/Models/SMILTypes.swift

--- a/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
+++ b/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
@@ -394,9 +394,11 @@ class FoliateManager {
     window.webkit?.messageHandlers?.Relocated?.postMessage(payload);
 
     if (this.#pendingHighlight) {
-      const { sectionIndex: pendingSectionIndex, textId } = this.#pendingHighlight;
+      const pendingHighlight = this.#pendingHighlight;
+      const { sectionIndex: pendingSectionIndex, textId } = pendingHighlight;
       debugLog("FoliateManager", `Checking pending highlight: section=${pendingSectionIndex}, textId=${textId}`);
       setTimeout(() => {
+        if (this.#pendingHighlight !== pendingHighlight) return;
         this.highlightFragment(pendingSectionIndex, textId);
       }, 50);
     }
@@ -1049,23 +1051,16 @@ class FoliateManager {
       return;
     }
 
+    let navigation = null;
     if (seekToLocation && sectionHref) {
       const pageInfo = this.#getElementPageInfo(el, doc, renderer);
       const intersectsCurrentPage = !renderer.scrolled && pageInfo?.visibleArea > 0;
       if (!intersectsCurrentPage) {
-        const smooth = renderer.scrolled;
-        debugLog(
-          "FoliateManager",
-          `seekToLocation enabled, navigating to ${sectionHref}#${textId} (smooth: ${smooth})`,
-        );
-        this.#pendingHighlight = { sectionIndex, textId };
-        this.#view.goTo(`${sectionHref}#${textId}`, { smooth });
-        return;
+        navigation = { smooth: renderer.scrolled };
+      } else {
+        debugLog("FoliateManager", `Element ${textId} already intersects the current page; skipping anchor navigation`);
       }
-      debugLog("FoliateManager", `Element ${textId} already intersects the current page; skipping anchor navigation`);
     }
-
-    this.#pendingHighlight = null;
 
     const activeClass = this.#view?.book?.media?.activeClass || "epub-media-overlay-active";
     el.classList.add(activeClass);
@@ -1080,6 +1075,18 @@ class FoliateManager {
     if (playbackActiveClass) {
       doc.documentElement.classList.add(playbackActiveClass);
     }
+
+    if (navigation) {
+      debugLog(
+        "FoliateManager",
+        `seekToLocation enabled, navigating to ${sectionHref}#${textId} (smooth: ${navigation.smooth})`,
+      );
+      this.#pendingHighlight = { sectionIndex, textId };
+      this.#view.goTo(`${sectionHref}#${textId}`, navigation);
+      return;
+    }
+
+    this.#pendingHighlight = null;
 
     const splitInfo = this.#getElementSplitInfo(el, doc, renderer);
     const visibleRatio = splitInfo?.visibleRatio ?? 1.0;

--- a/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
+++ b/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
@@ -177,6 +177,11 @@ class FoliateManager {
     debugLog("FoliateManager", "Opening file in foliate-view...");
     await this.#view.open(file);
 
+    // Foliate emits the final relocate event after its snap animation completes.
+    // Without animated mode, releasing a swipe jumps to the target page and
+    // publishes the new locator synchronously.
+    this.#view.renderer?.setAttribute("animated", "");
+
     this.#bookmarkManager.setView(this.#view);
 
     debugLog("FoliateManager", "Book opened, reporting structure to Swift");

--- a/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
+++ b/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
@@ -1053,9 +1053,13 @@ class FoliateManager {
       const pageInfo = this.#getElementPageInfo(el, doc, renderer);
       const intersectsCurrentPage = !renderer.scrolled && pageInfo?.visibleArea > 0;
       if (!intersectsCurrentPage) {
-        debugLog("FoliateManager", `seekToLocation enabled, navigating to ${sectionHref}#${textId}`);
+        const smooth = renderer.scrolled;
+        debugLog(
+          "FoliateManager",
+          `seekToLocation enabled, navigating to ${sectionHref}#${textId} (smooth: ${smooth})`,
+        );
         this.#pendingHighlight = { sectionIndex, textId };
-        this.#view.goTo(`${sectionHref}#${textId}`);
+        this.#view.goTo(`${sectionHref}#${textId}`, { smooth });
         return;
       }
       debugLog("FoliateManager", `Element ${textId} already intersects the current page; skipping anchor navigation`);

--- a/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
+++ b/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
@@ -1075,7 +1075,8 @@ class FoliateManager {
 
     window.webkit?.messageHandlers?.mediaOverlaySeek?.postMessage({
       sectionIndex: sectionIndex,
-      anchor: anchor
+      anchor: anchor,
+      startPlayback: true,
     });
   }
 

--- a/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
+++ b/SilveranKit/Sources/AppleKit/Resources/WebResources/FoliateManager.js
@@ -4,6 +4,10 @@ import { SpanHighlighter } from "./SpanHighlighter.js";
 import { debugLog } from "./DebugConfig.js";
 import BookmarkManager from "./BookmarkManager.js";
 
+const PLAYBACK_SELECTION_CLASS = "silveran-playback-active";
+const PLAYBACK_SELECTION_STYLE_ID = "silveran-playback-selection-style";
+const SCROLL_FOLLOW_RESUME_DELAY_MS = 2000;
+
 const getCSS = ({
   lineSpacing = 1.4,
   textAlign = "justify",
@@ -157,6 +161,13 @@ class FoliateManager {
   #highlightedSectionIndex = null;
   #resizeHandler = null;
   #pendingHighlight = null;
+  #isPlaybackActive = false;
+  #readerTouchActive = false;
+  #scrollAutoFollowSuppressed = false;
+  #scrollAutoFollowResumeTimer = null;
+  #latestPlaybackTarget = null;
+  #pagedAutoFollowDeferred = false;
+  #deferredAudioPageFlip = null;
   #bookmarkManager = (() => {
     console.log("[FoliateManager] Creating BookmarkManager instance");
     return new BookmarkManager();
@@ -181,6 +192,28 @@ class FoliateManager {
     // Without animated mode, releasing a swipe jumps to the target page and
     // publishes the new locator synchronously.
     this.#view.renderer?.setAttribute("animated", "");
+    this.#view.renderer?.addEventListener("scroll", () => {
+      this.#handleReaderScroll();
+    });
+    this.#view.renderer?.addEventListener("touchstart", (event) => {
+      this.#handleReaderTouchStart(event);
+    }, { capture: true, passive: true });
+    const handleRendererTouchEnd = (event) => {
+      this.#handleReaderTouchEnd(event);
+    };
+    this.#view.renderer?.addEventListener(
+      "touchend",
+      handleRendererTouchEnd,
+      { capture: true, passive: true },
+    );
+    this.#view.renderer?.addEventListener(
+      "touchcancel",
+      handleRendererTouchEnd,
+      { capture: true, passive: true },
+    );
+    this.#view.renderer?.addEventListener("wheel", () => {
+      this.#handleReaderWheel();
+    }, { capture: true, passive: true });
 
     this.#bookmarkManager.setView(this.#view);
 
@@ -205,6 +238,33 @@ class FoliateManager {
       const { doc, index } = detail;
       if (doc) {
         let isDragging = false;
+
+        this.#applyPlaybackSelectionPolicy(doc);
+
+        doc.addEventListener("touchstart", (event) => {
+          this.#handleReaderTouchStart(event);
+        }, { capture: true, passive: true });
+
+        const handleTouchEnd = (event) => {
+          this.#handleReaderTouchEnd(event);
+        };
+        doc.addEventListener("touchend", handleTouchEnd, { capture: true, passive: true });
+        doc.addEventListener("touchcancel", handleTouchEnd, { capture: true, passive: true });
+
+        doc.addEventListener("wheel", () => {
+          this.#handleReaderWheel();
+        }, { capture: true, passive: true });
+
+        doc.addEventListener("selectstart", (event) => {
+          if (this.#isPlaybackActive) event.preventDefault();
+        }, { capture: true });
+
+        doc.addEventListener("selectionchange", () => {
+          if (!this.#isPlaybackActive) return;
+          const selection = doc.getSelection?.();
+          selection?.removeAllRanges();
+          this.#bookmarkManager.hideSelectionToolbar();
+        });
 
         doc.addEventListener("touchmove", (event) => {
           const selection = doc.getSelection?.();
@@ -268,6 +328,131 @@ class FoliateManager {
     });
 
     debugLog("FoliateManager", "Event listeners attached");
+  }
+
+  #applyPlaybackSelectionPolicy(doc) {
+    if (!doc?.documentElement) return;
+
+    if (!doc.getElementById(PLAYBACK_SELECTION_STYLE_ID)) {
+      const style = doc.createElement("style");
+      style.id = PLAYBACK_SELECTION_STYLE_ID;
+      style.textContent = `
+        html.${PLAYBACK_SELECTION_CLASS},
+        html.${PLAYBACK_SELECTION_CLASS} * {
+          -webkit-user-select: none !important;
+          user-select: none !important;
+          -webkit-touch-callout: none !important;
+        }
+      `;
+      (doc.head || doc.documentElement).appendChild(style);
+    }
+
+    doc.documentElement.classList.toggle(
+      PLAYBACK_SELECTION_CLASS,
+      this.#isPlaybackActive,
+    );
+
+    if (this.#isPlaybackActive) {
+      const selection = doc.getSelection?.();
+      selection?.removeAllRanges();
+      this.#bookmarkManager.hideSelectionToolbar();
+    }
+  }
+
+  #isAutoFollowSuppressed(renderer = this.#view?.renderer) {
+    if (!this.#isPlaybackActive) return false;
+    return renderer?.scrolled
+      ? this.#readerTouchActive || this.#scrollAutoFollowSuppressed
+      : this.#readerTouchActive;
+  }
+
+  #suppressScrollAutoFollow() {
+    if (!this.#isPlaybackActive || !this.#view?.renderer?.scrolled) return;
+    this.#scrollAutoFollowSuppressed = true;
+    this.#pendingHighlight = null;
+    if (this.#scrollAutoFollowResumeTimer !== null) {
+      clearTimeout(this.#scrollAutoFollowResumeTimer);
+      this.#scrollAutoFollowResumeTimer = null;
+    }
+  }
+
+  #scheduleScrollAutoFollowResume() {
+    if (!this.#isPlaybackActive || !this.#scrollAutoFollowSuppressed) return;
+    if (this.#scrollAutoFollowResumeTimer !== null) {
+      clearTimeout(this.#scrollAutoFollowResumeTimer);
+      this.#scrollAutoFollowResumeTimer = null;
+    }
+    if (this.#readerTouchActive) return;
+
+    this.#scrollAutoFollowResumeTimer = setTimeout(() => {
+      this.#scrollAutoFollowResumeTimer = null;
+      if (!this.#isPlaybackActive || this.#readerTouchActive) return;
+      this.#scrollAutoFollowSuppressed = false;
+      this.#resumeLatestPlaybackTarget();
+    }, SCROLL_FOLLOW_RESUME_DELAY_MS);
+  }
+
+  #resumeLatestPlaybackTarget() {
+    const target = this.#latestPlaybackTarget;
+    if (!this.#isPlaybackActive || !target) return;
+    this.highlightFragment(target.sectionIndex, target.textId, true);
+  }
+
+  #resumePagedAutoFollow() {
+    if (!this.#isPlaybackActive || this.#readerTouchActive) return;
+    if (!this.#pagedAutoFollowDeferred) return;
+    this.#pagedAutoFollowDeferred = false;
+
+    const target = this.#latestPlaybackTarget;
+    const deferredFlip = this.#deferredAudioPageFlip;
+    this.#deferredAudioPageFlip = null;
+
+    if (
+      deferredFlip &&
+      (!target ||
+        (target.sectionIndex === deferredFlip.sectionIndex &&
+          target.textId === deferredFlip.textId))
+    ) {
+      if (target) this.#pendingHighlight = target;
+      this.#view?.goRight();
+      return;
+    }
+
+    this.#resumeLatestPlaybackTarget();
+  }
+
+  #handleReaderTouchStart(event) {
+    this.#readerTouchActive = (event.touches?.length ?? 1) > 0;
+    if (!this.#isPlaybackActive) return;
+
+    this.#pendingHighlight = null;
+    if (this.#view?.renderer?.scrolled) {
+      this.#suppressScrollAutoFollow();
+    }
+  }
+
+  #handleReaderTouchEnd(event) {
+    this.#readerTouchActive = (event.touches?.length ?? 0) > 0;
+    if (!this.#isPlaybackActive || this.#readerTouchActive) return;
+
+    if (this.#view?.renderer?.scrolled) {
+      this.#scheduleScrollAutoFollowResume();
+    } else {
+      this.#resumePagedAutoFollow();
+    }
+  }
+
+  #handleReaderWheel() {
+    if (!this.#isPlaybackActive || !this.#view?.renderer?.scrolled) return;
+    this.#suppressScrollAutoFollow();
+    this.#scheduleScrollAutoFollowResume();
+  }
+
+  #handleReaderScroll() {
+    if (!this.#isPlaybackActive || !this.#view?.renderer?.scrolled) return;
+    if (this.#scrollAutoFollowSuppressed) {
+      this.#scheduleScrollAutoFollowResume();
+    }
   }
 
   #handleKeyDown(event) {
@@ -518,6 +703,64 @@ class FoliateManager {
     this.#view.goRight();
   }
 
+  goRightForAudio(sectionIndex, textId) {
+    debugLog(
+      "FoliateManager",
+      `goRightForAudio(sectionIndex: ${sectionIndex}, textId: ${textId})`,
+    );
+    if (!this.#view) {
+      console.warn("[FM2] goRightForAudio() called but view not initialized");
+      return false;
+    }
+
+    const latestTarget = this.#latestPlaybackTarget;
+    if (
+      latestTarget &&
+      (latestTarget.sectionIndex !== sectionIndex || latestTarget.textId !== textId)
+    ) {
+      debugLog("FoliateManager", "Ignoring stale audio-follow page flip");
+      return false;
+    }
+
+    if (this.#isAutoFollowSuppressed()) {
+      if (!this.#view.renderer?.scrolled) {
+        this.#pagedAutoFollowDeferred = true;
+        this.#deferredAudioPageFlip = { sectionIndex, textId };
+      }
+      return false;
+    }
+
+    this.#view.goRight();
+    return true;
+  }
+
+  setPlaybackActive(active) {
+    const nextActive = !!active;
+    debugLog("FoliateManager", `setPlaybackActive(${nextActive})`);
+    this.#isPlaybackActive = nextActive;
+
+    for (const { doc } of this.#view?.renderer?.getContents?.() || []) {
+      this.#applyPlaybackSelectionPolicy(doc);
+    }
+
+    if (nextActive) {
+      if (this.#readerTouchActive && this.#view?.renderer?.scrolled) {
+        this.#suppressScrollAutoFollow();
+      }
+      return;
+    }
+
+    if (this.#scrollAutoFollowResumeTimer !== null) {
+      clearTimeout(this.#scrollAutoFollowResumeTimer);
+      this.#scrollAutoFollowResumeTimer = null;
+    }
+    this.#scrollAutoFollowSuppressed = false;
+    this.#latestPlaybackTarget = null;
+    this.#pagedAutoFollowDeferred = false;
+    this.#deferredAudioPageFlip = null;
+    this.#pendingHighlight = null;
+  }
+
   goTo(href) {
     debugLog("FoliateManager", "goTo() - href:", href);
     if (!this.#view) {
@@ -764,6 +1007,28 @@ class FoliateManager {
 
   #handleDoubleClick(event, sectionIndex, doc) {
     debugLog("FoliateManager", `Double-click detected in section ${sectionIndex}`);
+
+    if (this.#isPlaybackActive) {
+      const target =
+        event.target?.nodeType === Node.ELEMENT_NODE
+          ? event.target
+          : event.target?.parentElement;
+      const anchor = target?.closest?.("[id]")?.id;
+      if (!anchor) {
+        console.warn("[FM2] No sentence anchor found from playback double-tap");
+        return;
+      }
+
+      event.preventDefault();
+      const selection = doc.getSelection?.();
+      selection?.removeAllRanges();
+      debugLog(
+        "FoliateManager",
+        `Sending playback double-tap seek: section=${sectionIndex}, anchor=${anchor}`,
+      );
+      this.#reportSeekEvent(sectionIndex, anchor);
+      return;
+    }
 
     const selection = doc.getSelection?.();
     if (!selection) {
@@ -1024,10 +1289,25 @@ class FoliateManager {
       return;
     }
 
+    const playbackFollowSuppressed =
+      seekToLocation &&
+      this.#isPlaybackActive &&
+      this.#isAutoFollowSuppressed(renderer);
+    if (playbackFollowSuppressed && !renderer.scrolled) {
+      this.#pagedAutoFollowDeferred = true;
+    }
+    if (seekToLocation && this.#isPlaybackActive) {
+      this.#latestPlaybackTarget = { sectionIndex, textId };
+    }
+
     const contents = renderer.getContents?.();
     const sectionHref = this.#view.book?.sections?.[sectionIndex]?.id;
 
     if (!contents || !contents.length) {
+      if (playbackFollowSuppressed) {
+        this.#pendingHighlight = null;
+        return;
+      }
       debugLog("FoliateManager", "No contents loaded, storing pending highlight and navigating");
       this.#pendingHighlight = { sectionIndex, textId };
       if (sectionHref) this.#view.goTo(`${sectionHref}#${textId}`);
@@ -1036,6 +1316,10 @@ class FoliateManager {
 
     const content = contents.find(c => c.index === sectionIndex);
     if (!content?.doc) {
+      if (playbackFollowSuppressed) {
+        this.#pendingHighlight = null;
+        return;
+      }
       debugLog("FoliateManager", `Section ${sectionIndex} not currently loaded, storing pending highlight and navigating`);
       this.#pendingHighlight = { sectionIndex, textId };
       if (sectionHref) this.#view.goTo(`${sectionHref}#${textId}`);
@@ -1045,6 +1329,10 @@ class FoliateManager {
     const doc = content.doc;
     const el = doc.getElementById(textId);
     if (!el) {
+      if (playbackFollowSuppressed) {
+        this.#pendingHighlight = null;
+        return;
+      }
       debugLog("FoliateManager", `Element ${textId} not found yet in section ${sectionIndex}, storing as pending`);
       this.#pendingHighlight = { sectionIndex, textId };
       if (seekToLocation && sectionHref) this.#view.goTo(`${sectionHref}#${textId}`);
@@ -1074,6 +1362,11 @@ class FoliateManager {
     const playbackActiveClass = this.#view?.book?.media?.playbackActiveClass;
     if (playbackActiveClass) {
       doc.documentElement.classList.add(playbackActiveClass);
+    }
+
+    if (playbackFollowSuppressed) {
+      this.#pendingHighlight = null;
+      return;
     }
 
     if (navigation) {


### PR DESCRIPTION
- double tapping a sentence while paused starts playback
- during playback, highlighting text is disabled (due to behaviors described below)

Scroll mode:
- Automatic scroll adjustments, which keep the active sentence in the middle of the screen, are now smoothly animated
- While touching the reader view, automatic scroll adjustments are disabled, and remain disabled for a 2 second period after lifting your finger. This means if you're reading faster than the audio playback, you can scroll ahead and then you have 2 seconds to double tap to a later sentence to seek there

Paged mode:
- Resting a finger on the reader view during playback disables auto page flips. Lifting the finger instantly resumes the view following the audio
- Swiping between pages animates smoothly